### PR TITLE
Update encoders API to match the new design

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -6,6 +6,8 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+import torch
+from meds_torchdata import MEDSTorchBatch
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -18,5 +20,7 @@ def _setup_doctest_namespace(
             "datetime": datetime,
             "tempfile": tempfile,
             "Path": Path,
+            "torch": torch,
+            "MEDSTorchBatch": MEDSTorchBatch,
         }
     )

--- a/src/medrap/__init__.py
+++ b/src/medrap/__init__.py
@@ -7,7 +7,7 @@ from .configs import (
     float_tensor_config,
     instantiate_model,
 )
-from .encoders import MEDSCodeEncoder, TokenEmbeddingEncoder
+from .encoders import MEDSCodeEncoder, PatientEncoder, TabularEncoder, TokenEmbeddingEncoder
 from .fusion import ConcatFusion, ReplaceFusion
 from .heads import LinearHead
 from .model import RetrievalAugmentedModel
@@ -36,6 +36,7 @@ __all__ = [
     "MEDSCodeEncoder",
     "MaskedMeanPooling",
     "ModelOutput",
+    "PatientEncoder",
     "PipelineConfig",
     "QueryOutput",
     "RAPAppConfig",
@@ -44,6 +45,7 @@ __all__ = [
     "RetrievalEncoderOutput",
     "RetrieverOutput",
     "SequenceMeanQueryProjector",
+    "TabularEncoder",
     "TokenEmbeddingEncoder",
     "TopKPayloadRetriever",
     "TopKPayloadRetrieverConfig",

--- a/src/medrap/configs.py
+++ b/src/medrap/configs.py
@@ -11,7 +11,7 @@ import torch
 from hydra.core.config_store import ConfigStore
 from hydra_zen import builds, instantiate
 
-from .encoders import MEDSCodeEncoder, TokenEmbeddingEncoder
+from .encoders import MEDSCodeEncoder, TabularEncoder, TokenEmbeddingEncoder
 from .fusion import ConcatFusion, ReplaceFusion
 from .heads import LinearHead
 from .model import RetrievalAugmentedModel
@@ -49,6 +49,12 @@ TokenEmbeddingEncoderConfig = builds_any(
     vocab_size=1024,
     embedding_dim=4,
     zen_dataclass={"cls_name": "TokenEmbeddingEncoderConfig"},
+)
+TabularEncoderConfig = builds_any(
+    TabularEncoder,
+    vocab_size=1024,
+    embedding_dim=4,
+    zen_dataclass={"cls_name": "TabularEncoderConfig"},
 )
 LinearQueryProjectorConfig = builds_any(
     LinearQueryProjector,

--- a/src/medrap/encoders.py
+++ b/src/medrap/encoders.py
@@ -4,26 +4,53 @@ These components convert MEDS batch inputs into dense patient representation use
 downstream fusion.
 """
 
+from abc import ABC, abstractmethod
+
 from meds_torchdata import MEDSTorchBatch
 from torch import nn
 
 from .types import EncoderOutput
 
 
-class MEDSCodeEncoder(nn.Module):
-    """Simple encoder that forwards ``batch.code`` as patient state.
+class PatientEncoder(nn.Module, ABC):
+    """Abstract base for all patient encoders.
 
-    This is a minimal scaffold encoder for MEDS-style batches in
-    Subjec-Measurement mode. It performs no learned transformation. It reads
-    ``batch.code`` from a ``MEDSTorchBatch`` and returns it unchanged as the
-    encoded patient representation.
+    Subclasses must implement :meth:`encode`, which maps a ``MEDSTorchBatch``
+    to an ``EncoderOutput``.  The ``forward`` method delegates to ``encode``
+    so that the encoder can be used as a standard ``nn.Module``.
+    """
+
+    @abstractmethod
+    def encode(self, batch: MEDSTorchBatch) -> EncoderOutput:
+        """Encode a patient batch into a dense representation.
+
+        Args:
+            batch: A ``MEDSTorchBatch``.
+
+        Returns:
+            An ``EncoderOutput`` whose ``patient_state`` has shape
+            ``(B, S_ehr, D_ehr)``.
+        """
+
+    def forward(self, batch: MEDSTorchBatch) -> EncoderOutput:
+        """Call ``encode``."""
+        return self.encode(batch)
+
+
+class MEDSCodeEncoder(PatientEncoder):
+    """Scaffold sequence encoder that casts ``batch.code`` to a float representation.
+
+    This is a minimal, non-learned encoder for MEDS-style batches. It converts
+    the integer code ids to floats and unsqueezes a trailing dimension so the
+    output satisfies the sequence-mode shape contract ``(B, S_ehr, D_ehr)``
+    with ``D_ehr = 1``.
     """
 
     def __init__(self) -> None:
         super().__init__()
 
     def encode(self, batch: MEDSTorchBatch) -> EncoderOutput:
-        """Return ``batch.code`` as the encoded patient state.
+        """Return ``batch.code`` as a float tensor with a trailing embedding dim.
 
         Args:
             batch: A ``MEDSTorchBatch`` containing a ``code`` field of shape
@@ -31,34 +58,26 @@ class MEDSCodeEncoder(nn.Module):
 
         Returns:
             An ``EncoderOutput`` where ``patient_state`` has shape
-            ``(B, S_ehr)`` and is equal to ``batch.code``.
+            ``(B, S_ehr, 1)``.
 
         Examples:
-            >>> import torch
-            >>> from meds_torchdata import MEDSTorchBatch
             >>> encoder = MEDSCodeEncoder()
             >>> batch = MEDSTorchBatch(
             ...     code=torch.LongTensor([[11, 22, 0], [7, 3, 1]]),
-            ...     numeric_value=torch.FloatTensor([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]),
-            ...     numeric_value_mask=torch.BoolTensor([[False, False, False], [False, False, False]]),
-            ...     time_delta_days=torch.FloatTensor([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]),
+            ...     numeric_value=torch.zeros(2, 3),
+            ...     numeric_value_mask=torch.zeros(2, 3, dtype=torch.bool),
+            ...     time_delta_days=torch.zeros(2, 3),
             ... )
             >>> out = encoder.encode(batch)
             >>> tuple(out.patient_state.shape)
-            (2, 3)
-            >>> torch.equal(out.patient_state, batch.code)
-            True
+            (2, 3, 1)
+            >>> out.patient_state.dtype
+            torch.float32
         """
-        if batch.code is None:
-            raise ValueError("MEDSCodeEncoder requires batch code to be present.")
-        return EncoderOutput(patient_state=batch.code)
-
-    def forward(self, batch: MEDSTorchBatch) -> EncoderOutput:
-        """Call ``encode``."""
-        return self.encode(batch)
+        return EncoderOutput(patient_state=batch.code.float().unsqueeze(-1))
 
 
-class TokenEmbeddingEncoder(nn.Module):
+class TokenEmbeddingEncoder(PatientEncoder):
     """Sequence encoder that maps ``batch.code`` to learned token embeddings.
 
     This is a minimal learned sequence encoder for MEDS-style batches. It reads
@@ -88,14 +107,12 @@ class TokenEmbeddingEncoder(nn.Module):
             ``(B, S_ehr, D_ehr)``.
 
         Examples:
-            >>> import torch
-            >>> from meds_torchdata import MEDSTorchBatch
             >>> encoder = TokenEmbeddingEncoder(vocab_size=8, embedding_dim=2)
             >>> batch = MEDSTorchBatch(
             ...     code=torch.LongTensor([[1, 2, 0], [3, 4, 5]]),
-            ...     numeric_value=torch.zeros((2, 3), dtype=torch.float32),
-            ...     numeric_value_mask=torch.zeros((2, 3), dtype=torch.bool),
-            ...     time_delta_days=torch.zeros((2, 3), dtype=torch.float32),
+            ...     numeric_value=torch.zeros(2, 3),
+            ...     numeric_value_mask=torch.zeros(2, 3, dtype=torch.bool),
+            ...     time_delta_days=torch.zeros(2, 3),
             ... )
             >>> out = encoder.encode(batch)
             >>> tuple(out.patient_state.shape)
@@ -103,10 +120,53 @@ class TokenEmbeddingEncoder(nn.Module):
             >>> out.patient_state.dtype
             torch.float32
         """
-        if batch.code is None:
-            raise ValueError("TokenEmbeddingEncoder requires batch code to be present.")
         return EncoderOutput(patient_state=self.embedding(batch.code.long()))
 
-    def forward(self, batch: MEDSTorchBatch) -> EncoderOutput:
-        """Call ``encode``."""
-        return self.encode(batch)
+
+class TabularEncoder(PatientEncoder):
+    """Tabular encoder that pools a code sequence into a single patient vector.
+
+    Embeds ``batch.code`` via a learned embedding table and mean-pools across the
+    sequence dimension to produce a ``(B, 1, D_ehr)`` patient representation.
+
+    Args:
+        vocab_size: Size of the EHR code vocabulary.
+        embedding_dim: Output hidden size ``D_ehr``.
+    """
+
+    def __init__(self, *, vocab_size: int = 1024, embedding_dim: int = 4) -> None:
+        super().__init__()
+        self.vocab_size = int(vocab_size)
+        self.embedding_dim = int(embedding_dim)
+        self.embedding = nn.Embedding(self.vocab_size, self.embedding_dim)
+
+    def encode(self, batch: MEDSTorchBatch) -> EncoderOutput:
+        """Embed and mean-pool ``batch.code`` into a tabular patient state.
+
+        Args:
+            batch: A ``MEDSTorchBatch`` containing a ``code`` field of shape
+                ``(B, S_ehr)``.
+
+        Returns:
+            An ``EncoderOutput`` where ``patient_state`` has shape
+            ``(B, 1, D_ehr)``.
+
+        Examples:
+            >>> encoder = TabularEncoder(vocab_size=8, embedding_dim=2)
+            >>> batch = MEDSTorchBatch(
+            ...     code=torch.LongTensor([[1, 2, 0], [3, 4, 5]]),
+            ...     numeric_value=torch.zeros(2, 3),
+            ...     numeric_value_mask=torch.zeros(2, 3, dtype=torch.bool),
+            ...     time_delta_days=torch.zeros(2, 3),
+            ... )
+            >>> out = encoder.encode(batch)
+            >>> tuple(out.patient_state.shape)
+            (2, 1, 2)
+            >>> out.patient_state.dtype
+            torch.float32
+            >>> tuple(encoder(batch).patient_state.shape)
+            (2, 1, 2)
+        """
+        embedded = self.embedding(batch.code.long())  # (B, S_ehr, D_ehr)
+        pooled = embedded.mean(dim=1, keepdim=True)  # (B, 1, D_ehr)
+        return EncoderOutput(patient_state=pooled)

--- a/src/medrap/types.py
+++ b/src/medrap/types.py
@@ -4,10 +4,8 @@ This module defines the stage-by-stage outputs used by the RAP pipeline.
 
 Shape notation:
     - ``B``: batch size.
-    - ``*P``: per-sample encoded patient-state shape produced by the encoder.
-      In sequence mode, ``*P = (S_ehr, D_ehr)`` so patient state is
-      ``(B, S_ehr, D_ehr)``. In tabular mode, ``*P = (D_ehr,)`` so patient
-      state is ``(B, D_ehr)``.
+    - ``S_ehr``: EHR sequence length (1 in tabular mode).
+    - ``D_ehr``: EHR hidden / embedding dimension (1 for scaffold encoders).
     - ``*F``: per-sample fused-state shape produced by the fusion module.
       It depends on configuration (for example ``(S_ehr, D_fused)``,
       ``(D_ehr + D_mem,)``, or ``(D_mem,)``).
@@ -23,7 +21,8 @@ class EncoderOutput:
     """Output of encode.
 
     Attributes:
-        patient_state: Encoded patient representation with shape ``(B, *P)``.
+        patient_state: Encoded patient representation with shape
+            ``(B, S_ehr, D_ehr)``.
     """
 
     patient_state: Tensor
@@ -82,7 +81,8 @@ class FusionInput:
     """Input payload for fusion stages.
 
     Attributes:
-        patient_state: Encoded patient representation with shape ``(B, *P)``.
+        patient_state: Encoded patient representation with shape
+            ``(B, S_ehr, D_ehr)``.
         retrieval_memory: Encoded retrieval memory (for example
             ``(B, R, K, S_doc, D_mem)``).
         retrieval_step_ids: Optional retrieval step mapping ``(B, S_ehr)``.


### PR DESCRIPTION
Changes in this PR:
1. With the updated design doc encoder output is of shape: (B, S_ehr, D_ehr), where in some cases S_ehr is 1.
2. Include commonly used doctests imports in conftest.py so it can be reused.
3. Create a parent PatientEncoder class for encoders so we do not repeat the common code.
4. Add TabularEncoder.