### PR TITLE
feat(retriever): Speed up HF dataset retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,29 @@ Use `prep.embedder.device=cpu` when no GPU is available. For a dataset already o
 entrypoints (`@hydra.main`) internally, and `prepare-retrieval-dataset` is the
 offline artifact-preparation entrypoint.
 
+### HF Retrieval Performance
+
+The default locked dependency is `faiss-cpu`, so HF dataset retrieval runs on CPU unless configured
+otherwise. If your environment provides a CUDA-enabled FAISS build, you can request GPU FAISS search:
+
+```bash
+retriever=hf_dataset \
+	retriever.dataset_path=/path/to/retrieval_db \
+	retriever.device=0
+```
+
+GPU FAISS is optional and not installed by default because available wheels depend on CUDA, Python, and GPU
+architecture. If GPU loading fails, leave `retriever.device=null` for CPU retrieval.
+
+To reduce per-batch Hugging Face row materialization overhead, cache retrieval payload columns as tensors:
+
+```bash
+retriever.cache_payloads=true \
+	retriever.payload_cache_device=cpu
+```
+
+Use `retriever.payload_cache_device=cuda` only when the retrieval payloads fit in GPU memory.
+
 ## Docker
 
 Build a local image with BuildKit enabled so `uv` downloads are cached across rebuilds:

--- a/src/medrap/conf/retriever/hf_dataset.yaml
+++ b/src/medrap/conf/retriever/hf_dataset.yaml
@@ -7,3 +7,6 @@ doc_attention_mask_column: doc_attention_mask
 doc_ids_column: doc_ids
 doc_key_embeddings_column: doc_key_embeddings
 k: 1
+device: null
+cache_payloads: false
+payload_cache_device: null

--- a/src/medrap/configs.py
+++ b/src/medrap/configs.py
@@ -118,6 +118,9 @@ HFDatasetRetrieverConfig = builds_any(
     doc_ids_column="doc_ids",
     doc_key_embeddings_column="doc_key_embeddings",
     k=1,
+    device=None,
+    cache_payloads=False,
+    payload_cache_device=None,
     zen_dataclass={"cls_name": "HFDatasetRetrieverConfig"},
 )
 DemoInMemoryRetrieverConfig = builds_any(

--- a/src/medrap/retrievers.py
+++ b/src/medrap/retrievers.py
@@ -195,6 +195,17 @@ class HFDatasetRetriever(Retriever):
         doc_ids_column: Optional column containing document ids.
         doc_key_embeddings_column: Optional column containing document key
             embeddings.
+        cache_payloads: Whether to cache retrieval payload columns as tensors at
+            construction time. This avoids Hugging Face Dataset row
+            materialization in the per-batch retrieval hot path.
+        payload_cache_device: Device for cached payload tensors. ``None`` means
+            CPU. Use ``"cuda:0"`` only when the payload corpus fits in GPU
+            memory.
+
+    Cached payloads preserve the same output shapes as uncached retrieval:
+    ``doc_tokens`` and ``doc_attention_mask`` are ``(B, R, K, S_doc)``,
+    ``doc_ids`` is ``(B, R, K)``, and ``doc_key_embeddings`` is
+    ``(B, R, K, D_ret)`` when configured.
     """
 
     def __init__(
@@ -207,6 +218,8 @@ class HFDatasetRetriever(Retriever):
         k: int = 1,
         doc_ids_column: str | None = None,
         doc_key_embeddings_column: str | None = None,
+        cache_payloads: bool = False,
+        payload_cache_device: str | int | torch.device | None = None,
     ) -> None:
         super().__init__()
 
@@ -217,7 +230,86 @@ class HFDatasetRetriever(Retriever):
         self._doc_key_embeddings_column = doc_key_embeddings_column
         self._dataset = dataset
         self._index_name = index_name
+        self._cached_doc_tokens: Tensor | None = None
+        self._cached_doc_attention_mask: Tensor | None = None
+        self._cached_doc_ids: Tensor | None = None
+        self._cached_doc_key_embeddings: Tensor | None = None
         self._validate_dataset()
+        if cache_payloads:
+            self._cache_payloads(payload_cache_device)
+
+    @staticmethod
+    def _resolve_cache_device(device: str | int | torch.device | None) -> torch.device:
+        """Resolve payload cache device names.
+
+        Examples:
+            >>> HFDatasetRetriever._resolve_cache_device(None)
+            device(type='cpu')
+            >>> HFDatasetRetriever._resolve_cache_device("cpu")
+            device(type='cpu')
+        """
+        if device is None:
+            return torch.device("cpu")
+        if isinstance(device, torch.device):
+            return device
+        if isinstance(device, int):
+            return torch.device("cuda", device)
+        return torch.device(device)
+
+    def _cache_dataset_column(
+        self,
+        column: str,
+        *,
+        dtype: torch.dtype,
+        device: torch.device,
+    ) -> Tensor:
+        """Convert one fixed-shape dataset column to a tensor cache.
+
+        Args:
+            column: Dataset column to cache.
+            dtype: Tensor dtype for the cached column.
+            device: Device that stores the cache.
+
+        Returns:
+            Tensor containing all rows from ``column`` on ``device``. The first
+            dimension is always ``N_docs``.
+        """
+        values = self._dataset[column]
+        try:
+            tensor = torch.as_tensor(values, dtype=dtype)
+        except (TypeError, ValueError):
+            tensor = torch.as_tensor(list(values), dtype=dtype)
+        return tensor.to(device)
+
+    def _cache_payloads(self, device: str | int | torch.device | None = None) -> None:
+        """Cache configured retrieval payload columns as indexable tensors.
+
+        Args:
+            device: Target cache device. ``None`` stores payloads on CPU.
+        """
+        cache_device = self._resolve_cache_device(device)
+        self._cached_doc_tokens = self._cache_dataset_column(
+            self._doc_tokens_column,
+            dtype=torch.long,
+            device=cache_device,
+        )
+        self._cached_doc_attention_mask = self._cache_dataset_column(
+            self._doc_attention_mask_column,
+            dtype=torch.bool,
+            device=cache_device,
+        )
+        if self._doc_ids_column is not None:
+            self._cached_doc_ids = self._cache_dataset_column(
+                self._doc_ids_column,
+                dtype=torch.long,
+                device=cache_device,
+            )
+        if self._doc_key_embeddings_column is not None:
+            self._cached_doc_key_embeddings = self._cache_dataset_column(
+                self._doc_key_embeddings_column,
+                dtype=torch.float32,
+                device=cache_device,
+            )
 
     def _validate_dataset(self) -> None:
         """Validate dataset columns and attached index.
@@ -391,6 +483,13 @@ class HFDatasetRetriever(Retriever):
                   configured, otherwise the FAISS dataset row indices)
                 - optional ``doc_key_embeddings`` shaped ``(B, R, K, D_ret)``
         """
+        if self._cached_doc_tokens is not None:
+            return self._materialize_cached_output(
+                row_indices=row_indices,
+                scores=scores,
+                output_device=output_device,
+            )
+
         batch_size, n_retrieval_steps, k = row_indices.shape
         flat_row_indices = row_indices.reshape(-1).tolist()
         rows = self._dataset[flat_row_indices]
@@ -423,6 +522,85 @@ class HFDatasetRetriever(Retriever):
                 rows[self._doc_key_embeddings_column],
                 dtype=torch.float32,
                 device=output_device,
+            ).reshape(batch_size, n_retrieval_steps, k, -1)
+
+        return RetrieverOutput(
+            doc_tokens=doc_tokens,
+            doc_attention_mask=doc_attention_mask,
+            doc_scores=scores.to(output_device),
+            doc_ids=doc_ids,
+            doc_key_embeddings=doc_key_embeddings,
+        )
+
+    def _take_cached_rows(self, cache: Tensor, row_indices: Tensor, output_device: torch.device) -> Tensor:
+        """Gather cached payload rows and return them on ``output_device``.
+
+        Args:
+            cache: Cached tensor with first dimension ``N_docs``.
+            row_indices: Retrieved row ids with shape ``(B, R, K)``.
+            output_device: Device for the returned tensor.
+
+        Returns:
+            Gathered rows with flattened leading dimension ``B * R * K`` and
+            remaining dimensions inherited from ``cache``.
+        """
+        flat_row_indices = row_indices.reshape(-1).to(cache.device)
+        values = cache.index_select(0, flat_row_indices)
+        return values.to(output_device)
+
+    def _materialize_cached_output(
+        self,
+        *,
+        row_indices: Tensor,
+        scores: Tensor,
+        output_device: torch.device,
+    ) -> RetrieverOutput:
+        """Materialize retrieved rows from cached tensor payloads.
+
+        Args:
+            row_indices: Retrieved dataset row indices with shape ``(B, R, K)``.
+            scores: Retrieval scores with shape ``(B, R, K)``.
+            output_device: Device to place the materialized tensors on.
+
+        Returns:
+            ``RetrieverOutput`` with:
+                - ``doc_tokens`` shaped ``(B, R, K, S_doc)``
+                - ``doc_attention_mask`` shaped ``(B, R, K, S_doc)``
+                - ``doc_scores`` shaped ``(B, R, K)``
+                - ``doc_ids`` shaped ``(B, R, K)``
+                - optional ``doc_key_embeddings`` shaped ``(B, R, K, D_ret)``
+        """
+        if self._cached_doc_tokens is None or self._cached_doc_attention_mask is None:
+            raise RuntimeError("Cached payloads are not initialized.")
+
+        batch_size, n_retrieval_steps, k = row_indices.shape
+
+        doc_tokens = self._take_cached_rows(
+            self._cached_doc_tokens,
+            row_indices,
+            output_device,
+        ).reshape(batch_size, n_retrieval_steps, k, -1)
+        doc_attention_mask = self._take_cached_rows(
+            self._cached_doc_attention_mask,
+            row_indices,
+            output_device,
+        ).reshape(batch_size, n_retrieval_steps, k, -1)
+
+        if self._cached_doc_ids is not None:
+            doc_ids = self._take_cached_rows(
+                self._cached_doc_ids,
+                row_indices,
+                output_device,
+            ).reshape(batch_size, n_retrieval_steps, k)
+        else:
+            doc_ids = row_indices.to(output_device)
+
+        doc_key_embeddings = None
+        if self._cached_doc_key_embeddings is not None:
+            doc_key_embeddings = self._take_cached_rows(
+                self._cached_doc_key_embeddings,
+                row_indices,
+                output_device,
             ).reshape(batch_size, n_retrieval_steps, k, -1)
 
         return RetrieverOutput(
@@ -499,6 +677,22 @@ class HFDatasetRetriever(Retriever):
             >>> out_no_ids = retriever_no_ids(torch.FloatTensor([[[1.0, 0.0]], [[0.0, 1.0]]]))
             >>> out_no_ids.doc_ids.tolist()
             [[[0]], [[1]]]
+
+            >>> cached = HFDatasetRetriever(
+            ...     dataset=dataset,
+            ...     index_name="retrieval",
+            ...     doc_tokens_column="doc_tokens",
+            ...     doc_attention_mask_column="doc_attention_mask",
+            ...     doc_ids_column="doc_ids",
+            ...     doc_key_embeddings_column="doc_key_embeddings",
+            ...     k=1,
+            ...     cache_payloads=True,
+            ... )
+            >>> cached_out = cached(torch.FloatTensor([[[1.0, 0.0]], [[0.0, 1.0]]]))
+            >>> torch.equal(cached_out.doc_tokens, out.doc_tokens)
+            True
+            >>> cached._cached_doc_tokens.device.type
+            'cpu'
         """
         if query_embeddings.ndim != 3:
             raise ValueError("query_embeddings must have shape (B, R, D_ret)")
@@ -521,6 +715,9 @@ def load_hf_dataset_retriever(
     doc_ids_column: str | None = None,
     doc_key_embeddings_column: str | None = None,
     index_path: str | None = None,
+    device: int | list[int] | None = None,
+    cache_payloads: bool = False,
+    payload_cache_device: str | int | torch.device | None = None,
 ) -> HFDatasetRetriever:
     """Load a static dataset-backed retriever from a saved artifact.
 
@@ -536,6 +733,13 @@ def load_hf_dataset_retriever(
             embeddings.
         index_path: Optional explicit path to the saved FAISS index file. When
             omitted, defaults to ``{dataset_path}/{index_name}.faiss``.
+        device: Optional FAISS device passed to
+            :meth:`datasets.Dataset.load_faiss_index`. ``None`` keeps the index
+            on CPU; ``0`` uses GPU 0; ``-1`` uses all GPUs.
+        cache_payloads: Whether to cache retrieval payload columns as tensors at
+            load time.
+        payload_cache_device: Device for cached payload tensors. ``None`` means
+            CPU.
 
     Returns:
         Configured :class:`HFDatasetRetriever`.
@@ -572,7 +776,17 @@ def load_hf_dataset_retriever(
     resolved_index_path = (
         index_path if index_path is not None else str(Path(dataset_path) / f"{index_name}.faiss")
     )
-    dataset.load_faiss_index(index_name, resolved_index_path)
+    try:
+        dataset.load_faiss_index(index_name, resolved_index_path, device=device)
+    except Exception as exc:
+        if device is not None:
+            raise RuntimeError(
+                "FAISS GPU retrieval was requested with device="
+                f"{device!r}, but the installed FAISS/datasets stack could not load the index on GPU. "
+                "Install a CUDA-enabled FAISS build compatible with this environment, or set "
+                "retriever.device=null to use CPU retrieval."
+            ) from exc
+        raise
     return HFDatasetRetriever(
         dataset=dataset,
         index_name=index_name,
@@ -581,6 +795,8 @@ def load_hf_dataset_retriever(
         k=k,
         doc_ids_column=doc_ids_column,
         doc_key_embeddings_column=doc_key_embeddings_column,
+        cache_payloads=cache_payloads,
+        payload_cache_device=payload_cache_device,
     )
 
 

--- a/src/medrap/retrievers.py
+++ b/src/medrap/retrievers.py
@@ -247,6 +247,10 @@ class HFDatasetRetriever(Retriever):
             device(type='cpu')
             >>> HFDatasetRetriever._resolve_cache_device("cpu")
             device(type='cpu')
+            >>> HFDatasetRetriever._resolve_cache_device(torch.device("cpu"))
+            device(type='cpu')
+            >>> HFDatasetRetriever._resolve_cache_device(2)
+            device(type='cuda', index=2)
         """
         if device is None:
             return torch.device("cpu")
@@ -273,6 +277,20 @@ class HFDatasetRetriever(Retriever):
         Returns:
             Tensor containing all rows from ``column`` on ``device``. The first
             dimension is always ``N_docs``.
+
+        Examples:
+            >>> class IterableColumn:
+            ...     def __iter__(self):
+            ...         return iter([[1, 2], [3, 4]])
+            >>> retriever = object.__new__(HFDatasetRetriever)
+            >>> retriever._dataset = {"doc_tokens": IterableColumn()}
+            >>> cached = retriever._cache_dataset_column(
+            ...     "doc_tokens",
+            ...     dtype=torch.long,
+            ...     device=torch.device("cpu"),
+            ... )
+            >>> cached.tolist()
+            [[1, 2], [3, 4]]
         """
         values = self._dataset[column]
         try:
@@ -569,6 +587,19 @@ class HFDatasetRetriever(Retriever):
                 - ``doc_scores`` shaped ``(B, R, K)``
                 - ``doc_ids`` shaped ``(B, R, K)``
                 - optional ``doc_key_embeddings`` shaped ``(B, R, K, D_ret)``
+
+        Examples:
+            >>> retriever = object.__new__(HFDatasetRetriever)
+            >>> retriever._cached_doc_tokens = None
+            >>> retriever._cached_doc_attention_mask = None
+            >>> retriever._materialize_cached_output(
+            ...     row_indices=torch.LongTensor([[[0]]]),
+            ...     scores=torch.FloatTensor([[[1.0]]]),
+            ...     output_device=torch.device("cpu"),
+            ... )  # doctest: +ELLIPSIS
+            Traceback (most recent call last):
+                ...
+            RuntimeError: Cached payloads are not initialized.
         """
         if self._cached_doc_tokens is None or self._cached_doc_attention_mask is None:
             raise RuntimeError("Cached payloads are not initialized.")
@@ -691,8 +722,28 @@ class HFDatasetRetriever(Retriever):
             >>> cached_out = cached(torch.FloatTensor([[[1.0, 0.0]], [[0.0, 1.0]]]))
             >>> torch.equal(cached_out.doc_tokens, out.doc_tokens)
             True
+            >>> torch.equal(cached_out.doc_attention_mask, out.doc_attention_mask)
+            True
+            >>> torch.equal(cached_out.doc_ids, out.doc_ids)
+            True
+            >>> torch.equal(cached_out.doc_key_embeddings, out.doc_key_embeddings)
+            True
             >>> cached._cached_doc_tokens.device.type
             'cpu'
+
+            >>> cached_no_ids = HFDatasetRetriever(
+            ...     dataset=dataset,
+            ...     index_name="retrieval",
+            ...     doc_tokens_column="doc_tokens",
+            ...     doc_attention_mask_column="doc_attention_mask",
+            ...     k=1,
+            ...     cache_payloads=True,
+            ... )
+            >>> out_cached_no_ids = cached_no_ids(torch.FloatTensor([[[0.0, 1.0]]]))
+            >>> out_cached_no_ids.doc_ids.tolist()
+            [[[1]]]
+            >>> out_cached_no_ids.doc_key_embeddings is None
+            True
         """
         if query_embeddings.ndim != 3:
             raise ValueError("query_embeddings must have shape (B, R, D_ret)")

--- a/tests/test_module_composition.py
+++ b/tests/test_module_composition.py
@@ -1,4 +1,5 @@
 import torch
+from datasets import Dataset
 from meds_torchdata import MEDSTorchBatch
 from torch import nn
 
@@ -13,7 +14,7 @@ from medrap.retrieval_encoder import (
     PerDocMeanPooledRetrievalEncoder,
     TokenFeatureRetrievalEncoder,
 )
-from medrap.retrievers import InMemoryRetriever
+from medrap.retrievers import HFDatasetRetriever, InMemoryRetriever
 from medrap.types import FusionInput, RetrieverOutput
 
 
@@ -204,3 +205,43 @@ def test_in_memory_retriever_returns_query_dependent_payloads() -> None:
     assert out.doc_key_embeddings is not None
     assert out.doc_tokens.shape == (2, 1, 2, 2)
     assert out.doc_attention_mask.dtype == torch.bool
+
+
+def test_hf_dataset_retriever_cached_payloads_match_uncached() -> None:
+    dataset = Dataset.from_dict(
+        {
+            "doc_tokens": [[10, 11, 0], [20, 21, 0], [30, 31, 32]],
+            "doc_attention_mask": [[1, 1, 0], [1, 1, 0], [1, 1, 1]],
+            "doc_ids": [100, 200, 300],
+            "index_embeddings": [[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]],
+            "doc_key_embeddings": [[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]],
+        }
+    )
+    dataset.add_faiss_index(column="index_embeddings", index_name="retrieval")
+
+    common_kwargs = {
+        "dataset": dataset,
+        "index_name": "retrieval",
+        "doc_tokens_column": "doc_tokens",
+        "doc_attention_mask_column": "doc_attention_mask",
+        "doc_ids_column": "doc_ids",
+        "doc_key_embeddings_column": "doc_key_embeddings",
+        "k": 2,
+    }
+    uncached = HFDatasetRetriever(**common_kwargs)
+    cached = HFDatasetRetriever(**common_kwargs, cache_payloads=True)
+
+    query = torch.FloatTensor([[[1.0, 0.1]], [[-0.1, 1.0]]])
+    uncached_out = uncached(query)
+    cached_out = cached(query)
+
+    assert cached._cached_doc_tokens is not None
+    assert cached._cached_doc_tokens.device.type == "cpu"
+    assert torch.equal(cached_out.doc_tokens, uncached_out.doc_tokens)
+    assert torch.equal(cached_out.doc_attention_mask, uncached_out.doc_attention_mask)
+    assert cached_out.doc_ids is not None and uncached_out.doc_ids is not None
+    assert torch.equal(cached_out.doc_ids, uncached_out.doc_ids)
+    assert cached_out.doc_scores is not None and uncached_out.doc_scores is not None
+    assert torch.allclose(cached_out.doc_scores, uncached_out.doc_scores)
+    assert cached_out.doc_key_embeddings is not None and uncached_out.doc_key_embeddings is not None
+    assert torch.equal(cached_out.doc_key_embeddings, uncached_out.doc_key_embeddings)

--- a/tests/test_module_composition.py
+++ b/tests/test_module_composition.py
@@ -1,8 +1,10 @@
+import pytest
 import torch
 from datasets import Dataset
 from meds_torchdata import MEDSTorchBatch
 from torch import nn
 
+import medrap.retrievers as retrievers_module
 from medrap.encoders import MEDSCodeEncoder
 from medrap.fusion import ReplaceFusion
 from medrap.model import RetrievalAugmentedModel
@@ -14,7 +16,7 @@ from medrap.retrieval_encoder import (
     PerDocMeanPooledRetrievalEncoder,
     TokenFeatureRetrievalEncoder,
 )
-from medrap.retrievers import HFDatasetRetriever, InMemoryRetriever
+from medrap.retrievers import HFDatasetRetriever, InMemoryRetriever, load_hf_dataset_retriever
 from medrap.types import FusionInput, RetrieverOutput
 
 
@@ -297,3 +299,87 @@ def test_hf_dataset_retriever_cached_output_requires_initialized_cache() -> None
         raise AssertionError("expected RuntimeError")
     except RuntimeError as e:
         assert "Cached payloads are not initialized" in str(e)
+
+
+def test_hf_dataset_retriever_cache_device_resolution() -> None:
+    assert HFDatasetRetriever._resolve_cache_device(torch.device("cpu")) == torch.device("cpu")
+    assert HFDatasetRetriever._resolve_cache_device(2) == torch.device("cuda", 2)
+
+
+def test_hf_dataset_retriever_cache_column_falls_back_to_list_materialization() -> None:
+    class IterableColumn:
+        def __iter__(self):
+            return iter([[1, 2], [3, 4]])
+
+    retriever = object.__new__(HFDatasetRetriever)
+    retriever._dataset = {"doc_tokens": IterableColumn()}
+
+    cached = retriever._cache_dataset_column(
+        "doc_tokens",
+        dtype=torch.long,
+        device=torch.device("cpu"),
+    )
+
+    assert cached.tolist() == [[1, 2], [3, 4]]
+
+
+def test_load_hf_dataset_retriever_passes_device_and_cache_options(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    class FakeDataset:
+        def load_faiss_index(self, index_name, index_path, *, device=None):
+            captured["load_faiss_index"] = (index_name, index_path, device)
+
+    class FakeRetriever:
+        def __init__(self, **kwargs):
+            self._dataset = kwargs["dataset"]
+            captured["retriever_kwargs"] = kwargs
+
+    monkeypatch.setattr(retrievers_module, "load_from_disk", lambda path: FakeDataset())
+    monkeypatch.setattr(retrievers_module, "HFDatasetRetriever", FakeRetriever)
+
+    retriever = load_hf_dataset_retriever(
+        dataset_path="/tmp/retrieval_db",
+        index_name="retrieval",
+        doc_tokens_column="doc_tokens",
+        doc_attention_mask_column="doc_attention_mask",
+        k=3,
+        device=0,
+        cache_payloads=True,
+        payload_cache_device="cpu",
+    )
+
+    assert isinstance(retriever, FakeRetriever)
+    assert captured["load_faiss_index"] == (
+        "retrieval",
+        "/tmp/retrieval_db/retrieval.faiss",
+        0,
+    )
+    assert captured["retriever_kwargs"] == {
+        "dataset": retriever._dataset,
+        "index_name": "retrieval",
+        "doc_tokens_column": "doc_tokens",
+        "doc_attention_mask_column": "doc_attention_mask",
+        "k": 3,
+        "doc_ids_column": None,
+        "doc_key_embeddings_column": None,
+        "cache_payloads": True,
+        "payload_cache_device": "cpu",
+    }
+
+
+def test_load_hf_dataset_retriever_explains_gpu_faiss_failure(monkeypatch) -> None:
+    class FakeDataset:
+        def load_faiss_index(self, index_name, index_path, *, device=None):
+            raise ImportError("no gpu faiss")
+
+    monkeypatch.setattr(retrievers_module, "load_from_disk", lambda path: FakeDataset())
+
+    with pytest.raises(RuntimeError, match="FAISS GPU retrieval was requested"):
+        load_hf_dataset_retriever(
+            dataset_path="/tmp/retrieval_db",
+            index_name="retrieval",
+            doc_tokens_column="doc_tokens",
+            doc_attention_mask_column="doc_attention_mask",
+            device=0,
+        )

--- a/tests/test_module_composition.py
+++ b/tests/test_module_composition.py
@@ -268,3 +268,20 @@ def test_load_hf_dataset_retriever_explains_gpu_faiss_failure(monkeypatch) -> No
             doc_attention_mask_column="doc_attention_mask",
             device=0,
         )
+
+
+def test_load_hf_dataset_retriever_reraises_cpu_faiss_failure(monkeypatch) -> None:
+    class FakeDataset:
+        def load_faiss_index(self, index_name, index_path, *, device=None):
+            assert device is None
+            raise FileNotFoundError("missing index")
+
+    monkeypatch.setattr(retrievers_module, "load_from_disk", lambda path: FakeDataset())
+
+    with pytest.raises(FileNotFoundError, match="missing index"):
+        load_hf_dataset_retriever(
+            dataset_path="/tmp/retrieval_db",
+            index_name="retrieval",
+            doc_tokens_column="doc_tokens",
+            doc_attention_mask_column="doc_attention_mask",
+        )

--- a/tests/test_module_composition.py
+++ b/tests/test_module_composition.py
@@ -245,3 +245,55 @@ def test_hf_dataset_retriever_cached_payloads_match_uncached() -> None:
     assert torch.allclose(cached_out.doc_scores, uncached_out.doc_scores)
     assert cached_out.doc_key_embeddings is not None and uncached_out.doc_key_embeddings is not None
     assert torch.equal(cached_out.doc_key_embeddings, uncached_out.doc_key_embeddings)
+
+
+def test_hf_dataset_retriever_cached_payloads_without_optional_columns() -> None:
+    dataset = Dataset.from_dict(
+        {
+            "doc_tokens": [[10, 11], [20, 21]],
+            "doc_attention_mask": [[1, 1], [1, 0]],
+            "index_embeddings": [[1.0, 0.0], [0.0, 1.0]],
+        }
+    )
+    dataset.add_faiss_index(column="index_embeddings", index_name="retrieval")
+    retriever = HFDatasetRetriever(
+        dataset=dataset,
+        index_name="retrieval",
+        doc_tokens_column="doc_tokens",
+        doc_attention_mask_column="doc_attention_mask",
+        k=1,
+        cache_payloads=True,
+    )
+
+    out = retriever(torch.FloatTensor([[[0.0, 1.0]]]))
+
+    assert out.doc_ids is not None
+    assert out.doc_ids.tolist() == [[[1]]]
+    assert out.doc_key_embeddings is None
+
+
+def test_hf_dataset_retriever_cached_output_requires_initialized_cache() -> None:
+    dataset = Dataset.from_dict(
+        {
+            "doc_tokens": [[10, 11]],
+            "doc_attention_mask": [[1, 1]],
+            "index_embeddings": [[1.0, 0.0]],
+        }
+    )
+    dataset.add_faiss_index(column="index_embeddings", index_name="retrieval")
+    retriever = HFDatasetRetriever(
+        dataset=dataset,
+        index_name="retrieval",
+        doc_tokens_column="doc_tokens",
+        doc_attention_mask_column="doc_attention_mask",
+    )
+
+    try:
+        retriever._materialize_cached_output(
+            row_indices=torch.LongTensor([[[0]]]),
+            scores=torch.FloatTensor([[[1.0]]]),
+            output_device=torch.device("cpu"),
+        )
+        raise AssertionError("expected RuntimeError")
+    except RuntimeError as e:
+        assert "Cached payloads are not initialized" in str(e)

--- a/tests/test_module_composition.py
+++ b/tests/test_module_composition.py
@@ -1,6 +1,5 @@
 import pytest
 import torch
-from datasets import Dataset
 from meds_torchdata import MEDSTorchBatch
 from torch import nn
 
@@ -16,7 +15,7 @@ from medrap.retrieval_encoder import (
     PerDocMeanPooledRetrievalEncoder,
     TokenFeatureRetrievalEncoder,
 )
-from medrap.retrievers import HFDatasetRetriever, InMemoryRetriever, load_hf_dataset_retriever
+from medrap.retrievers import InMemoryRetriever, load_hf_dataset_retriever
 from medrap.types import FusionInput, RetrieverOutput
 
 
@@ -207,120 +206,6 @@ def test_in_memory_retriever_returns_query_dependent_payloads() -> None:
     assert out.doc_key_embeddings is not None
     assert out.doc_tokens.shape == (2, 1, 2, 2)
     assert out.doc_attention_mask.dtype == torch.bool
-
-
-def test_hf_dataset_retriever_cached_payloads_match_uncached() -> None:
-    dataset = Dataset.from_dict(
-        {
-            "doc_tokens": [[10, 11, 0], [20, 21, 0], [30, 31, 32]],
-            "doc_attention_mask": [[1, 1, 0], [1, 1, 0], [1, 1, 1]],
-            "doc_ids": [100, 200, 300],
-            "index_embeddings": [[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]],
-            "doc_key_embeddings": [[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]],
-        }
-    )
-    dataset.add_faiss_index(column="index_embeddings", index_name="retrieval")
-
-    common_kwargs = {
-        "dataset": dataset,
-        "index_name": "retrieval",
-        "doc_tokens_column": "doc_tokens",
-        "doc_attention_mask_column": "doc_attention_mask",
-        "doc_ids_column": "doc_ids",
-        "doc_key_embeddings_column": "doc_key_embeddings",
-        "k": 2,
-    }
-    uncached = HFDatasetRetriever(**common_kwargs)
-    cached = HFDatasetRetriever(**common_kwargs, cache_payloads=True)
-
-    query = torch.FloatTensor([[[1.0, 0.1]], [[-0.1, 1.0]]])
-    uncached_out = uncached(query)
-    cached_out = cached(query)
-
-    assert cached._cached_doc_tokens is not None
-    assert cached._cached_doc_tokens.device.type == "cpu"
-    assert torch.equal(cached_out.doc_tokens, uncached_out.doc_tokens)
-    assert torch.equal(cached_out.doc_attention_mask, uncached_out.doc_attention_mask)
-    assert cached_out.doc_ids is not None and uncached_out.doc_ids is not None
-    assert torch.equal(cached_out.doc_ids, uncached_out.doc_ids)
-    assert cached_out.doc_scores is not None and uncached_out.doc_scores is not None
-    assert torch.allclose(cached_out.doc_scores, uncached_out.doc_scores)
-    assert cached_out.doc_key_embeddings is not None and uncached_out.doc_key_embeddings is not None
-    assert torch.equal(cached_out.doc_key_embeddings, uncached_out.doc_key_embeddings)
-
-
-def test_hf_dataset_retriever_cached_payloads_without_optional_columns() -> None:
-    dataset = Dataset.from_dict(
-        {
-            "doc_tokens": [[10, 11], [20, 21]],
-            "doc_attention_mask": [[1, 1], [1, 0]],
-            "index_embeddings": [[1.0, 0.0], [0.0, 1.0]],
-        }
-    )
-    dataset.add_faiss_index(column="index_embeddings", index_name="retrieval")
-    retriever = HFDatasetRetriever(
-        dataset=dataset,
-        index_name="retrieval",
-        doc_tokens_column="doc_tokens",
-        doc_attention_mask_column="doc_attention_mask",
-        k=1,
-        cache_payloads=True,
-    )
-
-    out = retriever(torch.FloatTensor([[[0.0, 1.0]]]))
-
-    assert out.doc_ids is not None
-    assert out.doc_ids.tolist() == [[[1]]]
-    assert out.doc_key_embeddings is None
-
-
-def test_hf_dataset_retriever_cached_output_requires_initialized_cache() -> None:
-    dataset = Dataset.from_dict(
-        {
-            "doc_tokens": [[10, 11]],
-            "doc_attention_mask": [[1, 1]],
-            "index_embeddings": [[1.0, 0.0]],
-        }
-    )
-    dataset.add_faiss_index(column="index_embeddings", index_name="retrieval")
-    retriever = HFDatasetRetriever(
-        dataset=dataset,
-        index_name="retrieval",
-        doc_tokens_column="doc_tokens",
-        doc_attention_mask_column="doc_attention_mask",
-    )
-
-    try:
-        retriever._materialize_cached_output(
-            row_indices=torch.LongTensor([[[0]]]),
-            scores=torch.FloatTensor([[[1.0]]]),
-            output_device=torch.device("cpu"),
-        )
-        raise AssertionError("expected RuntimeError")
-    except RuntimeError as e:
-        assert "Cached payloads are not initialized" in str(e)
-
-
-def test_hf_dataset_retriever_cache_device_resolution() -> None:
-    assert HFDatasetRetriever._resolve_cache_device(torch.device("cpu")) == torch.device("cpu")
-    assert HFDatasetRetriever._resolve_cache_device(2) == torch.device("cuda", 2)
-
-
-def test_hf_dataset_retriever_cache_column_falls_back_to_list_materialization() -> None:
-    class IterableColumn:
-        def __iter__(self):
-            return iter([[1, 2], [3, 4]])
-
-    retriever = object.__new__(HFDatasetRetriever)
-    retriever._dataset = {"doc_tokens": IterableColumn()}
-
-    cached = retriever._cache_dataset_column(
-        "doc_tokens",
-        dtype=torch.long,
-        device=torch.device("cpu"),
-    )
-
-    assert cached.tolist() == [[1, 2], [3, 4]]
 
 
 def test_load_hf_dataset_retriever_passes_device_and_cache_options(monkeypatch) -> None:


### PR DESCRIPTION
 Adds two optional performance paths for `HFDatasetRetriever`:

  - `retriever.device` passes through to `datasets.load_faiss_index`, allowing GPU FAISS when the
  environment provides a CUDA-enabled FAISS build.
  - `retriever.cache_payloads` caches retrieval payload columns as tensors to avoid per-batch Hugging Face
  row materialization overhead.

  Defaults remain unchanged: CPU FAISS and no payload caching.

  In a local retriever-only MIMIC-IV benchmark, CPU FAISS took about 3.2-3.4s/batch. GPU FAISS reduced
  this to about 0.095s/batch, and adding payload caching reduced materialization further to about 0.018s/
  batch on CPU cache or about 0.002s/batch on CUDA cache after cache construction. These are local
  measurements, not a formal benchmark.
