### PR TITLE
 Add random retrieval ablation

### DIFF
--- a/src/medrap/conf/retriever/hf_dataset.yaml
+++ b/src/medrap/conf/retriever/hf_dataset.yaml
@@ -8,5 +8,6 @@ doc_ids_column: doc_ids
 doc_key_embeddings_column: doc_key_embeddings
 k: 1
 device: null
+ablation_mode: none
 cache_payloads: false
 payload_cache_device: null

--- a/src/medrap/configs.py
+++ b/src/medrap/configs.py
@@ -119,6 +119,7 @@ HFDatasetRetrieverConfig = builds_any(
     doc_key_embeddings_column="doc_key_embeddings",
     k=1,
     device=None,
+    ablation_mode="none",
     cache_payloads=False,
     payload_cache_device=None,
     zen_dataclass={"cls_name": "HFDatasetRetrieverConfig"},

--- a/src/medrap/retrievers.py
+++ b/src/medrap/retrievers.py
@@ -29,6 +29,73 @@ def _move_tensors_to_device(device: torch.device, *tensors: Tensor) -> tuple[Ten
     return tuple(tensor if tensor.device == device else tensor.to(device) for tensor in tensors)
 
 
+def _apply_retrieval_ablation(
+    *,
+    ablation_mode: str,
+    dataset_num_rows: int,
+    scores: Tensor,
+    row_indices: Tensor,
+) -> tuple[Tensor, Tensor]:
+    """Apply configured retrieval ablation to searched row ids.
+
+    Args:
+        ablation_mode: Retrieval ablation mode, one of ``"none"`` or
+            ``"random_docs"``.
+        dataset_num_rows: Number of rows in the retrieval dataset.
+        scores: Retrieval scores with shape ``(B, R, K)``.
+        row_indices: Retrieved dataset row indices with shape ``(B, R, K)``.
+
+    Returns:
+        Possibly ablated ``(scores, row_indices)``. ``random_docs`` returns
+        uniform random row ids sampled with replacement and zero scores.
+
+    Examples:
+        >>> scores = torch.FloatTensor([[[1.0]], [[2.0]]])
+        >>> rows = torch.LongTensor([[[10]], [[20]]])
+        >>> out_scores, out_rows = _apply_retrieval_ablation(
+        ...     ablation_mode="none",
+        ...     dataset_num_rows=100,
+        ...     scores=scores,
+        ...     row_indices=rows,
+        ... )
+        >>> torch.equal(out_scores, scores), torch.equal(out_rows, rows)
+        (True, True)
+
+        >>> _ = torch.manual_seed(1)
+        >>> out_scores, out_rows = _apply_retrieval_ablation(
+        ...     ablation_mode="random_docs",
+        ...     dataset_num_rows=100,
+        ...     scores=scores,
+        ...     row_indices=rows,
+        ... )
+        >>> out_rows.shape == rows.shape and out_rows.max() < 100 and out_rows.min() >= 0
+        tensor(True)
+        >>> torch.equal(out_scores, torch.zeros_like(scores))
+        True
+
+        >>> _apply_retrieval_ablation(
+        ...     ablation_mode="bad",
+        ...     dataset_num_rows=100,
+        ...     scores=scores,
+        ...     row_indices=rows,
+        ... )  # doctest: +ELLIPSIS
+        Traceback (most recent call last):
+            ...
+        RuntimeError: Unsupported retrieval ablation mode: 'bad'
+    """
+    if ablation_mode == "none":
+        return scores, row_indices
+    if ablation_mode == "random_docs":
+        random_rows = torch.randint(
+            dataset_num_rows,
+            row_indices.shape,
+            device=row_indices.device,
+            dtype=row_indices.dtype,
+        )
+        return torch.zeros_like(scores), random_rows
+    raise RuntimeError(f"Unsupported retrieval ablation mode: {ablation_mode!r}")
+
+
 class Retriever(nn.Module, ABC):
     """Abstract base class for retrievers.
 
@@ -488,47 +555,6 @@ class HFDatasetRetriever(Retriever):
         )
         return scores, row_indices
 
-    def _apply_ablation(self, *, scores: Tensor, row_indices: Tensor) -> tuple[Tensor, Tensor]:
-        """Apply configured retrieval ablation to searched row ids.
-
-        Args:
-            scores: Retrieval scores with shape ``(B, R, K)``.
-            row_indices: Retrieved dataset row indices with shape ``(B, R, K)``.
-
-        Returns:
-            Possibly ablated ``(scores, row_indices)``. ``random_docs`` returns
-            uniform random row ids sampled with replacement and zero scores.
-
-        Examples:
-            >>> retriever = object.__new__(HFDatasetRetriever)
-            >>> retriever.ablation_mode = "none"
-            >>> scores = torch.FloatTensor([[[1.0]], [[2.0]]])
-            >>> rows = torch.LongTensor([[[10]], [[20]]])
-            >>> out_scores, out_rows = retriever._apply_ablation(scores=scores, row_indices=rows)
-            >>> torch.equal(out_scores, scores), torch.equal(out_rows, rows)
-            (True, True)
-
-            >>> retriever.ablation_mode = "random_docs"
-            >>> retriever._dataset_num_rows = 100
-            >>> _ = torch.manual_seed(1)
-            >>> out_scores, out_rows = retriever._apply_ablation(scores=scores, row_indices=rows)
-            >>> out_rows.shape == rows.shape and out_rows.max() < 100 and out_rows.min() >= 0
-            tensor(True)
-            >>> torch.equal(out_scores, torch.zeros_like(scores))
-            True
-        """
-        if self.ablation_mode == "none":
-            return scores, row_indices
-        if self.ablation_mode == "random_docs":
-            random_rows = torch.randint(
-                self._dataset_num_rows,
-                row_indices.shape,
-                device=row_indices.device,
-                dtype=row_indices.dtype,
-            )
-            return torch.zeros_like(scores), random_rows
-        raise RuntimeError(f"Unsupported retrieval ablation mode: {self.ablation_mode!r}")
-
     def _materialize_output(
         self,
         *,
@@ -811,7 +837,12 @@ class HFDatasetRetriever(Retriever):
             raise ValueError("query_embeddings must have shape (B, R, D_ret)")
 
         scores, row_indices = self._search_index(query_embeddings)
-        scores, row_indices = self._apply_ablation(scores=scores, row_indices=row_indices)
+        scores, row_indices = _apply_retrieval_ablation(
+            ablation_mode=self.ablation_mode,
+            dataset_num_rows=self._dataset_num_rows,
+            scores=scores,
+            row_indices=row_indices,
+        )
         return self._materialize_output(
             row_indices=row_indices,
             scores=scores,

--- a/src/medrap/retrievers.py
+++ b/src/medrap/retrievers.py
@@ -196,12 +196,9 @@ class HFDatasetRetriever(Retriever):
         doc_key_embeddings_column: Optional column containing document key
             embeddings.
         ablation_mode: Retrieval ablation mode. ``"none"`` returns normal
-            nearest-neighbor results. ``"shuffle_batch"`` permutes complete
-            retrieved top-k sets across batch items, preserving the retrieved
-            payload distribution while breaking patient-document alignment.
-            ``"random_docs"`` replaces nearest-neighbor rows with random corpus
-            rows, breaking both patient-document alignment and retrieved payload
-            distribution.
+            nearest-neighbor results. ``"random_docs"`` replaces
+            nearest-neighbor rows with random corpus rows, breaking
+            patient-document alignment.
         cache_payloads: Whether to cache retrieval payload columns as tensors at
             construction time. This avoids Hugging Face Dataset row
             materialization in the per-batch retrieval hot path.
@@ -231,8 +228,8 @@ class HFDatasetRetriever(Retriever):
     ) -> None:
         super().__init__()
 
-        if ablation_mode not in {"none", "shuffle_batch", "random_docs"}:
-            raise ValueError("ablation_mode must be one of: 'none', 'shuffle_batch', 'random_docs'")
+        if ablation_mode not in {"none", "random_docs"}:
+            raise ValueError("ablation_mode must be one of: 'none', 'random_docs'")
         self.k = k
         self.ablation_mode = ablation_mode
         self._doc_tokens_column = doc_tokens_column
@@ -509,12 +506,6 @@ class HFDatasetRetriever(Retriever):
             >>> torch.equal(out_scores, scores), torch.equal(out_rows, rows)
             (True, True)
 
-            >>> retriever.ablation_mode = "shuffle_batch"
-            >>> _ = torch.manual_seed(1)
-            >>> out_scores, out_rows = retriever._apply_ablation(scores=scores, row_indices=rows)
-            >>> out_rows.tolist(), out_scores.tolist()
-            ([[[20]], [[10]]], [[[2.0]], [[1.0]]])
-
             >>> retriever.ablation_mode = "random_docs"
             >>> retriever._dataset_num_rows = 100
             >>> _ = torch.manual_seed(1)
@@ -526,11 +517,6 @@ class HFDatasetRetriever(Retriever):
         """
         if self.ablation_mode == "none":
             return scores, row_indices
-        if self.ablation_mode == "shuffle_batch":
-            if row_indices.shape[0] < 2:
-                return scores, row_indices
-            permutation = torch.randperm(row_indices.shape[0], device=row_indices.device)
-            return scores.index_select(0, permutation), row_indices.index_select(0, permutation)
         if self.ablation_mode == "random_docs":
             random_rows = torch.randint(
                 self._dataset_num_rows,
@@ -817,7 +803,7 @@ class HFDatasetRetriever(Retriever):
             ... )  # doctest: +ELLIPSIS
             Traceback (most recent call last):
                 ...
-            ValueError: ablation_mode must be one of: 'none', 'shuffle_batch', 'random_docs'
+            ValueError: ablation_mode must be one of: 'none', 'random_docs'
         """
         if query_embeddings.ndim != 3:
             raise ValueError("query_embeddings must have shape (B, R, D_ret)")

--- a/src/medrap/retrievers.py
+++ b/src/medrap/retrievers.py
@@ -195,6 +195,13 @@ class HFDatasetRetriever(Retriever):
         doc_ids_column: Optional column containing document ids.
         doc_key_embeddings_column: Optional column containing document key
             embeddings.
+        ablation_mode: Retrieval ablation mode. ``"none"`` returns normal
+            nearest-neighbor results. ``"shuffle_batch"`` permutes complete
+            retrieved top-k sets across batch items, preserving the retrieved
+            payload distribution while breaking patient-document alignment.
+            ``"random_docs"`` replaces nearest-neighbor rows with random corpus
+            rows, breaking both patient-document alignment and retrieved payload
+            distribution.
         cache_payloads: Whether to cache retrieval payload columns as tensors at
             construction time. This avoids Hugging Face Dataset row
             materialization in the per-batch retrieval hot path.
@@ -218,17 +225,22 @@ class HFDatasetRetriever(Retriever):
         k: int = 1,
         doc_ids_column: str | None = None,
         doc_key_embeddings_column: str | None = None,
+        ablation_mode: str = "none",
         cache_payloads: bool = False,
         payload_cache_device: str | int | torch.device | None = None,
     ) -> None:
         super().__init__()
 
+        if ablation_mode not in {"none", "shuffle_batch", "random_docs"}:
+            raise ValueError("ablation_mode must be one of: 'none', 'shuffle_batch', 'random_docs'")
         self.k = k
+        self.ablation_mode = ablation_mode
         self._doc_tokens_column = doc_tokens_column
         self._doc_attention_mask_column = doc_attention_mask_column
         self._doc_ids_column = doc_ids_column
         self._doc_key_embeddings_column = doc_key_embeddings_column
         self._dataset = dataset
+        self._dataset_num_rows = len(dataset)
         self._index_name = index_name
         self._cached_doc_tokens: Tensor | None = None
         self._cached_doc_attention_mask: Tensor | None = None
@@ -477,6 +489,57 @@ class HFDatasetRetriever(Retriever):
             self.k,
         )
         return scores, row_indices
+
+    def _apply_ablation(self, *, scores: Tensor, row_indices: Tensor) -> tuple[Tensor, Tensor]:
+        """Apply configured retrieval ablation to searched row ids.
+
+        Args:
+            scores: Retrieval scores with shape ``(B, R, K)``.
+            row_indices: Retrieved dataset row indices with shape ``(B, R, K)``.
+
+        Returns:
+            Possibly ablated ``(scores, row_indices)``.
+
+        Examples:
+            >>> retriever = object.__new__(HFDatasetRetriever)
+            >>> retriever.ablation_mode = "none"
+            >>> scores = torch.FloatTensor([[[1.0]], [[2.0]]])
+            >>> rows = torch.LongTensor([[[10]], [[20]]])
+            >>> out_scores, out_rows = retriever._apply_ablation(scores=scores, row_indices=rows)
+            >>> torch.equal(out_scores, scores), torch.equal(out_rows, rows)
+            (True, True)
+
+            >>> retriever.ablation_mode = "shuffle_batch"
+            >>> _ = torch.manual_seed(1)
+            >>> out_scores, out_rows = retriever._apply_ablation(scores=scores, row_indices=rows)
+            >>> out_rows.tolist(), out_scores.tolist()
+            ([[[20]], [[10]]], [[[2.0]], [[1.0]]])
+
+            >>> retriever.ablation_mode = "random_docs"
+            >>> retriever._dataset_num_rows = 100
+            >>> _ = torch.manual_seed(1)
+            >>> out_scores, out_rows = retriever._apply_ablation(scores=scores, row_indices=rows)
+            >>> out_rows.shape == rows.shape and out_rows.max() < 100 and out_rows.min() >= 0
+            tensor(True)
+            >>> torch.equal(out_scores, torch.zeros_like(scores))
+            True
+        """
+        if self.ablation_mode == "none":
+            return scores, row_indices
+        if self.ablation_mode == "shuffle_batch":
+            if row_indices.shape[0] < 2:
+                return scores, row_indices
+            permutation = torch.randperm(row_indices.shape[0], device=row_indices.device)
+            return scores.index_select(0, permutation), row_indices.index_select(0, permutation)
+        if self.ablation_mode == "random_docs":
+            random_rows = torch.randint(
+                self._dataset_num_rows,
+                row_indices.shape,
+                device=row_indices.device,
+                dtype=row_indices.dtype,
+            )
+            return torch.zeros_like(scores), random_rows
+        raise RuntimeError(f"Unsupported retrieval ablation mode: {self.ablation_mode!r}")
 
     def _materialize_output(
         self,
@@ -744,11 +807,23 @@ class HFDatasetRetriever(Retriever):
             [[[1]]]
             >>> out_cached_no_ids.doc_key_embeddings is None
             True
+
+            >>> HFDatasetRetriever(
+            ...     dataset=dataset,
+            ...     index_name="retrieval",
+            ...     doc_tokens_column="doc_tokens",
+            ...     doc_attention_mask_column="doc_attention_mask",
+            ...     ablation_mode="bad",
+            ... )  # doctest: +ELLIPSIS
+            Traceback (most recent call last):
+                ...
+            ValueError: ablation_mode must be one of: 'none', 'shuffle_batch', 'random_docs'
         """
         if query_embeddings.ndim != 3:
             raise ValueError("query_embeddings must have shape (B, R, D_ret)")
 
         scores, row_indices = self._search_index(query_embeddings)
+        scores, row_indices = self._apply_ablation(scores=scores, row_indices=row_indices)
         return self._materialize_output(
             row_indices=row_indices,
             scores=scores,
@@ -767,6 +842,7 @@ def load_hf_dataset_retriever(
     doc_key_embeddings_column: str | None = None,
     index_path: str | None = None,
     device: int | list[int] | None = None,
+    ablation_mode: str = "none",
     cache_payloads: bool = False,
     payload_cache_device: str | int | torch.device | None = None,
 ) -> HFDatasetRetriever:
@@ -787,6 +863,8 @@ def load_hf_dataset_retriever(
         device: Optional FAISS device passed to
             :meth:`datasets.Dataset.load_faiss_index`. ``None`` keeps the index
             on CPU; ``0`` uses GPU 0; ``-1`` uses all GPUs.
+        ablation_mode: Retrieval ablation mode passed to
+            :class:`HFDatasetRetriever`.
         cache_payloads: Whether to cache retrieval payload columns as tensors at
             load time.
         payload_cache_device: Device for cached payload tensors. ``None`` means
@@ -846,6 +924,7 @@ def load_hf_dataset_retriever(
         k=k,
         doc_ids_column=doc_ids_column,
         doc_key_embeddings_column=doc_key_embeddings_column,
+        ablation_mode=ablation_mode,
         cache_payloads=cache_payloads,
         payload_cache_device=payload_cache_device,
     )

--- a/src/medrap/retrievers.py
+++ b/src/medrap/retrievers.py
@@ -197,8 +197,9 @@ class HFDatasetRetriever(Retriever):
             embeddings.
         ablation_mode: Retrieval ablation mode. ``"none"`` returns normal
             nearest-neighbor results. ``"random_docs"`` replaces
-            nearest-neighbor rows with random corpus rows, breaking
-            patient-document alignment.
+            nearest-neighbor row ids with uniform random corpus row ids sampled
+            with replacement, breaking patient-document alignment while keeping
+            the same payload materialization path.
         cache_payloads: Whether to cache retrieval payload columns as tensors at
             construction time. This avoids Hugging Face Dataset row
             materialization in the per-batch retrieval hot path.
@@ -495,7 +496,8 @@ class HFDatasetRetriever(Retriever):
             row_indices: Retrieved dataset row indices with shape ``(B, R, K)``.
 
         Returns:
-            Possibly ablated ``(scores, row_indices)``.
+            Possibly ablated ``(scores, row_indices)``. ``random_docs`` returns
+            uniform random row ids sampled with replacement and zero scores.
 
         Examples:
             >>> retriever = object.__new__(HFDatasetRetriever)

--- a/tests/test_module_composition.py
+++ b/tests/test_module_composition.py
@@ -230,6 +230,7 @@ def test_load_hf_dataset_retriever_passes_device_and_cache_options(monkeypatch) 
         doc_attention_mask_column="doc_attention_mask",
         k=3,
         device=0,
+        ablation_mode="random_docs",
         cache_payloads=True,
         payload_cache_device="cpu",
     )
@@ -248,6 +249,7 @@ def test_load_hf_dataset_retriever_passes_device_and_cache_options(monkeypatch) 
         "k": 3,
         "doc_ids_column": None,
         "doc_key_embeddings_column": None,
+        "ablation_mode": "random_docs",
         "cache_payloads": True,
         "payload_cache_device": "cpu",
     }

--- a/tests/test_module_composition.py
+++ b/tests/test_module_composition.py
@@ -208,7 +208,7 @@ def test_in_memory_retriever_returns_query_dependent_payloads() -> None:
     assert out.doc_attention_mask.dtype == torch.bool
 
 
-def test_load_hf_dataset_retriever_passes_device_and_cache_options(monkeypatch) -> None:
+def test_load_hf_dataset_retriever_passes_device_cache_and_ablation_options(monkeypatch) -> None:
     captured: dict[str, object] = {}
 
     class FakeDataset:


### PR DESCRIPTION
 Adds `retriever.ablation_mode=random_docs` for HF dataset retrievers.

 This keeps the normal retrieval path, then replaces retrieved row ids with uniform random corpus rows
 sampled with replacement and zeroes retrieval scores. The control is intended for measuring whether
 retrieval gains come from patient-specific retrieved documents versus the retrieval branch architecture/
 document noise.

 Default behavior remains unchanged with `ablation_mode=none`.
