### PR TITLE
Use flat CLI entrypoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ Subsystems and tooling:
     comorbidity flagging (`comorbidity.py`), demographic × keyword heatmaps
     (`demographic_analysis.py`), and an LLM-as-a-judge retrieval-relevance
     pipeline (`llm_judge.py`).
-- **CLI** (`cli.py`): `medrap train`, `medrap eval`, and
-    `medrap prepare-retrieval-dataset`, all Hydra-native.
+- **CLI** (`cli.py`): `medrap-train`, `medrap-eval`, and
+    `medrap-prepare-retrieval-dataset`, all Hydra-native.
 - Hydra config groups under `medrap/conf` for every stage plus the `training/`
     and `prep/` trees.
 
@@ -117,33 +117,33 @@ variant) lives in the `RetrievalAugmentedModel` docstring in `model.py`.
 
 ## CLI
 
-`medrap` exposes three Hydra-native subcommands; all accept Hydra overrides and
-`medrap train`/`medrap eval` require an `output_dir`.
+`medrap` exposes three Hydra-native entrypoints; all accept Hydra overrides and
+`medrap-train`/`medrap-eval` require an `output_dir`.
 
 A CPU smoke run on the built-in synthetic datamodule (no external data needed):
 
 ```bash
-uv run medrap train output_dir=/tmp/medrap_smoke \
+uv run medrap-train output_dir=/tmp/medrap_smoke \
 	training/datamodule=synthetic training/trainer=lightning_demo
 ```
 
 Train and evaluate on real (tensorized MEDS) data:
 
 ```bash
-uv run medrap train output_dir=outputs/run_001 training/datamodule=meds
-uv run medrap eval output_dir=outputs/run_001_eval \
+uv run medrap-train output_dir=outputs/run_001 training/datamodule=meds
+uv run medrap-eval output_dir=outputs/run_001_eval \
 	checkpoint_path=outputs/run_001/best_model.ckpt
 ```
 
 Re-running into an existing `output_dir` is rejected unless you pass
 `do_overwrite=true` or `do_resume=true` (train), or choose a fresh `output_dir`
-(eval). `medrap eval` also accepts `eval_mode=validate` (default) or
+(eval). `medrap-eval` also accepts `eval_mode=validate` (default) or
 `eval_mode=test`.
 
 Build a local Hugging Face dataset + FAISS index for retrieval (requires the `prep` extra, e.g. `uv pip install "medrap[prep]"`). Example: Hub source, then save under `prep.output.output_dir`:
 
 ```bash
-uv run medrap prepare-retrieval-dataset \
+uv run medrap-prepare-retrieval-dataset \
 	prep.source.path=MedRAG/textbooks prep.source.split=train \
 	prep.document.fields='[title,content]' \
 	prep.tokenizer.pretrained_model_name_or_path=Qwen/Qwen3-Embedding-0.6B \
@@ -158,9 +158,8 @@ uv run medrap prepare-retrieval-dataset \
 
 Use `prep.embedder.device=cpu` when no GPU is available. For a dataset already on disk, switch the source group: `prep/source=load_from_disk` and set `prep.source.dataset_path=...`.
 
-`medrap` is a thin dispatcher; `train` and `eval` are implemented as Hydra-native
-entrypoints (`@hydra.main`) internally, and `prepare-retrieval-dataset` is the
-offline artifact-preparation entrypoint.
+These commands are direct Hydra entrypoints (`@hydra.main`), so Hydra receives
+overrides without an intermediate subcommand dispatcher.
 
 ### HF Retrieval Performance
 
@@ -210,7 +209,7 @@ The image is intended to consume prebuilt artifacts. For training, mount:
 Quick smoke check:
 
 ```bash
-docker run --rm medrap:local medrap --help
+docker run --rm medrap:local medrap-train --help
 ```
 
 Example training invocation:
@@ -222,7 +221,7 @@ docker run --rm --gpus all \
 	-v /host/retrieval_db:/data/retrieval_db:ro \
 	-v /host/outputs:/outputs \
 	medrap:local \
-	medrap train \
+	medrap-train \
 	retriever=hf_dataset \
 	retriever.dataset_path=/data/retrieval_db \
 	training/datamodule=meds \

--- a/README.md
+++ b/README.md
@@ -85,7 +85,10 @@ model = RetrievalAugmentedModel(
     query_projector=SequenceMeanQueryProjector(in_dim=1, out_dim=4),
     retriever=InMemoryRetriever(
         doc_key_embeddings=torch.FloatTensor(
-            [[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]]
+            [
+                [1.0, 0.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0, 0.0],
+            ]
         ),
         doc_tokens=torch.LongTensor([[1, 2], [3, 4]]),
         doc_attention_mask=torch.BoolTensor([[True, True], [True, True]]),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,9 @@ default-groups = ["dev", "llm_judge", "viz"]
 medrap = ["conf/**/*.yaml"]
 
 [project.scripts]
-medrap = "medrap.cli:main"
+medrap-train = "medrap.cli:train_main"
+medrap-eval = "medrap.cli:eval_main"
+medrap-prepare-retrieval-dataset = "medrap.cli:prepare_retrieval_dataset_main"
 
 [tool.pytest.ini_options]
 testpaths = ["tests", "src/medrap"]

--- a/src/medrap/cli.py
+++ b/src/medrap/cli.py
@@ -1,10 +1,7 @@
 """CLI entrypoints for medrap."""
 
-import argparse
 import os
 import shutil
-import sys
-from collections.abc import Sequence
 from pathlib import Path
 
 import hydra
@@ -319,7 +316,7 @@ def _run_eval(cfg: DictConfig) -> int:
     output_dir = _prepare_eval_run(cfg)
     checkpoint_path = cfg.checkpoint_path
     if not checkpoint_path:
-        raise ValueError("checkpoint_path must be set for medrap eval.")
+        raise ValueError("checkpoint_path must be set for medrap-eval.")
 
     module = _load_training_module_checkpoint(cfg, checkpoint_path)
     bound_cfg = _bind_trainer_paths(cfg, output_dir=output_dir)
@@ -337,65 +334,19 @@ def _run_eval(cfg: DictConfig) -> int:
 
 
 @hydra.main(version_base=None, config_path="conf", config_name="_train")
-def _train_hydra(cfg: DictConfig) -> int:
+def train_main(cfg: DictConfig) -> int:
+    """Run the Hydra-native training entrypoint."""
     return _run_train(cfg)
 
 
 @hydra.main(version_base=None, config_path="conf", config_name="_eval")
-def _eval_hydra(cfg: DictConfig) -> int:
+def eval_main(cfg: DictConfig) -> int:
+    """Run the Hydra-native evaluation entrypoint."""
     return _run_eval(cfg)
 
 
 @hydra.main(version_base=None, config_path="conf", config_name="_prepare_retrieval_dataset")
-def _prepare_retrieval_dataset_hydra(cfg: DictConfig) -> int:
+def prepare_retrieval_dataset_main(cfg: DictConfig) -> int:
+    """Run the Hydra-native retrieval-dataset preparation entrypoint."""
     prepare_retrieval_dataset_from_config(cfg)
     return 0
-
-
-def train_main(overrides: Sequence[str] | None = None) -> int:
-    """Run the Hydra-native train entrypoint."""
-    old_argv = sys.argv
-    try:
-        sys.argv = [old_argv[0] if old_argv else "medrap-train", *(list(overrides or []))]
-        result = _train_hydra()
-        return int(result) if isinstance(result, int) else 0
-    finally:
-        sys.argv = old_argv
-
-
-def eval_main(overrides: Sequence[str] | None = None) -> int:
-    """Run the Hydra-native eval entrypoint."""
-    old_argv = sys.argv
-    try:
-        sys.argv = [old_argv[0] if old_argv else "medrap-eval", *(list(overrides or []))]
-        result = _eval_hydra()
-        return int(result) if isinstance(result, int) else 0
-    finally:
-        sys.argv = old_argv
-
-
-def prepare_retrieval_dataset_main(overrides: Sequence[str] | None = None) -> int:
-    """Run the Hydra-native retrieval dataset preparation entrypoint."""
-    old_argv = sys.argv
-    try:
-        sys.argv = [old_argv[0] if old_argv else "medrap-prepare-retrieval-dataset", *(list(overrides or []))]
-        result = _prepare_retrieval_dataset_hydra()
-        return int(result) if isinstance(result, int) else 0
-    finally:
-        sys.argv = old_argv
-
-
-def main(argv: Sequence[str] | None = None) -> int:
-    """Dispatch medrap subcommands to Hydra-native entrypoints."""
-    parser = argparse.ArgumentParser(prog="medrap")
-    subparsers = parser.add_subparsers(dest="command", required=True)
-    for cmd in ("train", "eval", "prepare-retrieval-dataset"):
-        sub = subparsers.add_parser(cmd)
-        sub.add_argument("overrides", nargs="*", help="Hydra overrides, e.g. retriever.k=2")
-
-    args = parser.parse_args(argv)
-    if args.command == "train":
-        return train_main(args.overrides)
-    if args.command == "prepare-retrieval-dataset":
-        return prepare_retrieval_dataset_main(args.overrides)
-    return eval_main(args.overrides)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -79,13 +79,6 @@ def test_medrap_eval_entrypoint_runs_with_overrides(tmp_path) -> None:
     assert (eval_dir / "resolved_config.yaml").exists()
 
 
-def test_train_entrypoint_runs_with_hydra_overrides(tmp_path) -> None:
-    output_dir = tmp_path / "train"
-
-    assert _run_train_cli([f"output_dir={output_dir}", "training/datamodule=synthetic"]) == 0
-    assert (output_dir / "checkpoints" / "last.ckpt").exists()
-
-
 def test_flat_entrypoint_scripts_are_registered() -> None:
     pyproject = tomllib.loads(Path("pyproject.toml").read_text())
     medrap_scripts = pyproject["project"]["scripts"]
@@ -139,26 +132,6 @@ def test_prepare_retrieval_dataset_entrypoint_runs_with_hydra_overrides(monkeypa
         "output_dir": str(output_dir),
         "max_length": 3,
     }
-
-
-def test_eval_entrypoint_runs_with_hydra_overrides(tmp_path) -> None:
-    output_dir = tmp_path / "train"
-    eval_dir = tmp_path / "eval"
-    checkpoint_path = output_dir / "checkpoints" / "last.ckpt"
-    assert _run_train_cli([f"output_dir={output_dir}", "training/datamodule=synthetic"]) == 0
-
-    assert (
-        _run_eval_cli(
-            [
-                f"output_dir={eval_dir}",
-                f"checkpoint_path={checkpoint_path}",
-                "training/datamodule=synthetic",
-            ]
-        )
-        == 0
-    )
-    assert (eval_dir / "config.yaml").exists()
-    assert (eval_dir / "resolved_config.yaml").exists()
 
 
 def test_eval_entrypoint_requires_checkpoint_path(tmp_path) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,5 @@
+import sys
+import tomllib
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -8,7 +10,7 @@ from omegaconf import OmegaConf
 from omegaconf.errors import MissingMandatoryValue
 
 import medrap.cli as cli
-from medrap.cli import eval_main, main, prepare_retrieval_dataset_main, train_main
+from medrap.cli import eval_main, prepare_retrieval_dataset_main, train_main
 
 TINY_SENTENCE_TRANSFORMER_MODEL = "sentence-transformers-testing/stsb-bert-tiny-safetensors"
 
@@ -23,26 +25,49 @@ def _assert_cli_failure(
         assert expected_message in str(exc_info.value)
 
 
-def test_medrap_train_cli_runs_with_overrides(tmp_path) -> None:
+def _run_hydra_entrypoint(entrypoint, prog: str, overrides: list[str]) -> int:
+    old_argv = sys.argv
+    try:
+        sys.argv = [prog, *overrides]
+        result = entrypoint()
+        return int(result) if isinstance(result, int) else 0
+    finally:
+        sys.argv = old_argv
+
+
+def _run_train_cli(overrides: list[str]) -> int:
+    return _run_hydra_entrypoint(train_main, "medrap-train", overrides)
+
+
+def _run_eval_cli(overrides: list[str]) -> int:
+    return _run_hydra_entrypoint(eval_main, "medrap-eval", overrides)
+
+
+def _run_prepare_retrieval_dataset_cli(overrides: list[str]) -> int:
+    return _run_hydra_entrypoint(
+        prepare_retrieval_dataset_main, "medrap-prepare-retrieval-dataset", overrides
+    )
+
+
+def test_medrap_train_entrypoint_runs_with_overrides(tmp_path) -> None:
     output_dir = tmp_path / "train"
 
-    assert main(["train", f"output_dir={output_dir}", "training/datamodule=synthetic"]) == 0
+    assert _run_train_cli([f"output_dir={output_dir}", "training/datamodule=synthetic"]) == 0
     assert (output_dir / "config.yaml").exists()
     assert (output_dir / "resolved_config.yaml").exists()
     assert (output_dir / "checkpoints" / "last.ckpt").exists()
     assert (output_dir / "best_model.ckpt").exists()
 
 
-def test_medrap_eval_cli_runs_with_overrides(tmp_path) -> None:
+def test_medrap_eval_entrypoint_runs_with_overrides(tmp_path) -> None:
     output_dir = tmp_path / "train"
     eval_dir = tmp_path / "eval"
     checkpoint_path = output_dir / "checkpoints" / "last.ckpt"
-    assert train_main([f"output_dir={output_dir}", "training/datamodule=synthetic"]) == 0
+    assert _run_train_cli([f"output_dir={output_dir}", "training/datamodule=synthetic"]) == 0
 
     assert (
-        main(
+        _run_eval_cli(
             [
-                "eval",
                 f"output_dir={eval_dir}",
                 f"checkpoint_path={checkpoint_path}",
                 "training/datamodule=synthetic",
@@ -57,21 +82,18 @@ def test_medrap_eval_cli_runs_with_overrides(tmp_path) -> None:
 def test_train_entrypoint_runs_with_hydra_overrides(tmp_path) -> None:
     output_dir = tmp_path / "train"
 
-    assert train_main([f"output_dir={output_dir}", "training/datamodule=synthetic"]) == 0
+    assert _run_train_cli([f"output_dir={output_dir}", "training/datamodule=synthetic"]) == 0
     assert (output_dir / "checkpoints" / "last.ckpt").exists()
 
 
-def test_medrap_prepare_retrieval_dataset_dispatches(monkeypatch) -> None:
-    called: list[list[str]] = []
+def test_flat_entrypoint_scripts_are_registered() -> None:
+    pyproject = tomllib.loads(Path("pyproject.toml").read_text())
+    medrap_scripts = pyproject["project"]["scripts"]
 
-    def _fake_main(overrides: list[str]) -> int:
-        called.append(overrides)
-        return 0
-
-    monkeypatch.setattr("medrap.cli.prepare_retrieval_dataset_main", _fake_main)
-
-    assert main(["prepare-retrieval-dataset", "prep.output.output_dir=tmp"]) == 0
-    assert called == [["prep.output.output_dir=tmp"]]
+    assert "medrap" not in medrap_scripts
+    assert medrap_scripts["medrap-train"] == "medrap.cli:train_main"
+    assert medrap_scripts["medrap-eval"] == "medrap.cli:eval_main"
+    assert medrap_scripts["medrap-prepare-retrieval-dataset"] == "medrap.cli:prepare_retrieval_dataset_main"
 
 
 def test_prepare_retrieval_dataset_entrypoint_runs_with_hydra_overrides(monkeypatch, tmp_path) -> None:
@@ -94,7 +116,7 @@ def test_prepare_retrieval_dataset_entrypoint_runs_with_hydra_overrides(monkeypa
     output_dir = tmp_path / "prepared"
 
     assert (
-        prepare_retrieval_dataset_main(
+        _run_prepare_retrieval_dataset_cli(
             [
                 "prep/source=load_from_disk",
                 f"prep.source.dataset_path={source_dir}",
@@ -123,10 +145,10 @@ def test_eval_entrypoint_runs_with_hydra_overrides(tmp_path) -> None:
     output_dir = tmp_path / "train"
     eval_dir = tmp_path / "eval"
     checkpoint_path = output_dir / "checkpoints" / "last.ckpt"
-    assert train_main([f"output_dir={output_dir}", "training/datamodule=synthetic"]) == 0
+    assert _run_train_cli([f"output_dir={output_dir}", "training/datamodule=synthetic"]) == 0
 
     assert (
-        eval_main(
+        _run_eval_cli(
             [
                 f"output_dir={eval_dir}",
                 f"checkpoint_path={checkpoint_path}",
@@ -141,7 +163,7 @@ def test_eval_entrypoint_runs_with_hydra_overrides(tmp_path) -> None:
 
 def test_eval_entrypoint_requires_checkpoint_path(tmp_path) -> None:
     _assert_cli_failure(
-        lambda: eval_main([f"output_dir={tmp_path / 'eval'}", "training/datamodule=synthetic"]),
+        lambda: _run_eval_cli([f"output_dir={tmp_path / 'eval'}", "training/datamodule=synthetic"]),
         allowed_exceptions=(SystemExit, MissingMandatoryValue, ValueError),
         expected_message="checkpoint_path",
     )
@@ -167,10 +189,10 @@ def test_prepare_train_run_overwrite_removes_stale_files(tmp_path: Path) -> None
 
 def test_train_entrypoint_refuses_existing_output_dir_without_flags(tmp_path) -> None:
     output_dir = tmp_path / "train"
-    assert train_main([f"output_dir={output_dir}", "training/datamodule=synthetic"]) == 0
+    assert _run_train_cli([f"output_dir={output_dir}", "training/datamodule=synthetic"]) == 0
 
     _assert_cli_failure(
-        lambda: train_main([f"output_dir={output_dir}", "training/datamodule=synthetic"]),
+        lambda: _run_train_cli([f"output_dir={output_dir}", "training/datamodule=synthetic"]),
         allowed_exceptions=(SystemExit, FileExistsError),
         expected_message="already contains a saved MedRAP run",
     )
@@ -178,19 +200,21 @@ def test_train_entrypoint_refuses_existing_output_dir_without_flags(tmp_path) ->
 
 def test_train_entrypoint_supports_resume_from_output_dir(tmp_path) -> None:
     output_dir = tmp_path / "train"
-    assert train_main([f"output_dir={output_dir}", "training/datamodule=synthetic"]) == 0
+    assert _run_train_cli([f"output_dir={output_dir}", "training/datamodule=synthetic"]) == 0
 
-    assert train_main([f"output_dir={output_dir}", "training/datamodule=synthetic", "do_resume=true"]) == 0
+    assert (
+        _run_train_cli([f"output_dir={output_dir}", "training/datamodule=synthetic", "do_resume=true"]) == 0
+    )
 
 
 def test_eval_entrypoint_supports_test_mode(tmp_path) -> None:
     output_dir = tmp_path / "train"
     eval_dir = tmp_path / "eval"
     checkpoint_path = output_dir / "checkpoints" / "last.ckpt"
-    assert train_main([f"output_dir={output_dir}", "training/datamodule=synthetic"]) == 0
+    assert _run_train_cli([f"output_dir={output_dir}", "training/datamodule=synthetic"]) == 0
 
     assert (
-        eval_main(
+        _run_eval_cli(
             [
                 f"output_dir={eval_dir}",
                 f"checkpoint_path={checkpoint_path}",
@@ -206,9 +230,9 @@ def test_eval_entrypoint_refuses_existing_output_dir(tmp_path) -> None:
     output_dir = tmp_path / "train"
     eval_dir = tmp_path / "eval"
     checkpoint_path = output_dir / "checkpoints" / "last.ckpt"
-    assert train_main([f"output_dir={output_dir}", "training/datamodule=synthetic"]) == 0
+    assert _run_train_cli([f"output_dir={output_dir}", "training/datamodule=synthetic"]) == 0
     assert (
-        eval_main(
+        _run_eval_cli(
             [
                 f"output_dir={eval_dir}",
                 f"checkpoint_path={checkpoint_path}",
@@ -219,7 +243,7 @@ def test_eval_entrypoint_refuses_existing_output_dir(tmp_path) -> None:
     )
 
     _assert_cli_failure(
-        lambda: eval_main(
+        lambda: _run_eval_cli(
             [
                 f"output_dir={eval_dir}",
                 f"checkpoint_path={checkpoint_path}",


### PR DESCRIPTION
## Summary
- replace the `medrap <subcommand>` dispatcher with direct console scripts
- register `medrap-train`, `medrap-eval`, and `medrap-prepare-retrieval-dataset`
- update README examples and CLI tests for the flat entrypoints

## Testing
- `uv run pytest -q`
- pre-commit hooks during commit