### PR TITLE
fix(fusion): add PerDocCrossAttentionFusion, guard marginalized_retrieval against incompatible fusions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ Implemented stage components:
     `MeanPooledRetrievalEncoder`, `PerDocMeanPooledRetrievalEncoder`,
     `LinearProjectionRetrievalEncoder`, `KeyEmbeddingRetrievalEncoder`.
 - **Fusion** (`fusion.py`): `ReplaceFusion`, `ConcatFusion`, `PassthroughFusion`
-    (retrieval-ablation baseline), `CrossAttentionFusion`.
+    (retrieval-ablation baseline), `CrossAttentionFusion`, `PerDocCrossAttentionFusion`
+    (per-document cross-attention; required for `marginalized_retrieval` with attention-based fusion).
 - **Pooling** (`pooling.py`): `IdentityPooling`, `MaskedMeanPooling`.
 - **Heads** (`heads.py`): `LinearHead`.
 - **Tasks & losses** (`task.py`, `losses.py`): binary, marginalized-binary, and
@@ -246,7 +247,7 @@ Hydra component groups live in `src/medrap/conf/`. Pipeline-stage groups:
 - `query_projector/` — `linear`, `sequence_mean`, `sequence_mean_1024`
 - `retriever/` — `in_memory`, `in_memory_sanity`, `in_memory_from_pt`, `hf_dataset`
 - `retrieval_encoder/` — `token_feature`, `mean_pooled`, `per_doc_mean_pooled`, `linear_projection`, `key_embedding`
-- `fusion/` — `replace`, `concat`, `passthrough`, `cross_attention_medium`
+- `fusion/` — `replace`, `concat`, `passthrough`, `cross_attention_medium`, `cross_attention_perdoc_medium`
 - `pooling/` — `identity`, `masked_mean`
 - `head/` — `linear`, `linear_1024_to_2`
 

--- a/src/medrap/__init__.py
+++ b/src/medrap/__init__.py
@@ -17,7 +17,14 @@ from .model.encoders import (
     TimeDeltaRoPEPatientEncoder,
     TokenEmbeddingEncoder,
 )
-from .model.fusion import ConcatFusion, CrossAttentionFusion, FusionModule, PassthroughFusion, ReplaceFusion
+from .model.fusion import (
+    ConcatFusion,
+    CrossAttentionFusion,
+    FusionModule,
+    PassthroughFusion,
+    PerDocCrossAttentionFusion,
+    ReplaceFusion,
+)
 from .model.heads import LinearHead, PredictionHead
 from .model.model import RetrievalAugmentedModel
 from .model.pooling import IdentityPooling, MaskedMeanPooling, PoolingModule
@@ -75,6 +82,7 @@ __all__ = [
     "OrderedFieldDocumentRenderer",
     "PassthroughFusion",
     "PatientEncoder",
+    "PerDocCrossAttentionFusion",
     "PerDocMeanPooledRetrievalEncoder",
     "PipelineConfig",
     "PoolingModule",

--- a/src/medrap/conf/fusion/cross_attention_perdoc_medium.yaml
+++ b/src/medrap/conf/fusion/cross_attention_perdoc_medium.yaml
@@ -1,0 +1,8 @@
+_target_: medrap.model.fusion.PerDocCrossAttentionFusion
+d_model: 256
+num_heads: 8
+ff_dim: 512
+num_layers: 2
+d_in_patient: ${encoder.embedding_dim}
+d_in_doc: ${retrieval_encoder.embedding_dim}
+dropout: 0.1

--- a/src/medrap/model/fusion.py
+++ b/src/medrap/model/fusion.py
@@ -19,7 +19,17 @@ class FusionModule(nn.Module, ABC):
     retrieval memory into a fused representation.  The ``forward`` method
     delegates to ``fuse`` so that the module can be used as a standard
     ``nn.Module``.
+
+    Attributes:
+        produces_per_document_state: Whether ``fused_state`` is indexed by
+            retrieved document (``(B, K, D)``) rather than by EHR sequence
+            position (``(B, S_ehr, D)``). :class:`~medrap.model.model.RetrievalAugmentedModel`
+            requires this to be ``True`` when ``marginalized_retrieval=True``,
+            since the marginalization sums over dim 1 expecting it to range
+            over retrieved documents.
     """
+
+    produces_per_document_state: bool = False
 
     @abstractmethod
     def fuse(self, fusion_input: FusionInput) -> FusionOutput:
@@ -48,6 +58,8 @@ class ReplaceFusion(FusionModule):
       ``(B, K, D_mem)`` when ``R = 1`` and the singleton doc-length dim is 1; otherwise
       ``(B, R * K * S_doc, D_mem)``.
     """
+
+    produces_per_document_state = True
 
     def __init__(self) -> None:
         super().__init__()
@@ -376,3 +388,154 @@ class CrossAttentionFusion(FusionModule):
             x = layer(x, kv, key_padding_mask)
 
         return FusionOutput(fused_state=self.out_norm(x))
+
+
+class PerDocCrossAttentionFusion(FusionModule):
+    """Cross-attention fusion that attends to each retrieved document independently.
+
+    Unlike :class:`CrossAttentionFusion` — which attends jointly to all ``K``
+    documents and produces ``(B, S_ehr, d_model)`` indexed by EHR sequence
+    position — this module expands the batch to ``B * K``, runs cross-attention
+    between each patient and exactly one of its retrieved documents, then
+    mean-pools over the patient sequence to produce one vector per document.
+
+    The resulting ``(B, K, d_model)`` output is indexed by retrieved document,
+    so it is compatible with REALM-style marginalized retrieval
+    (:attr:`~medrap.model.model.RetrievalAugmentedModel.marginalized_retrieval`)
+    at any value of ``K`` — unlike ``CrossAttentionFusion``, which marginalizes
+    over EHR sequence positions instead of documents when paired with that flag.
+
+    Only ``R = 1`` retrieval step is supported.
+
+    Args:
+        d_model: Internal model dimension after input projection.
+        num_heads: Number of attention heads (must divide ``d_model``).
+        ff_dim: Hidden dimension of the position-wise feed-forward network.
+        num_layers: Number of stacked cross-attention layers.
+        d_in_patient: Input dimension of ``patient_state`` (``D_ehr``).
+        d_in_doc: Input dimension of ``retrieval_memory`` token vectors (``D_mem``).
+        dropout: Dropout probability applied inside attention and FFN.
+
+    Input shapes (via :class:`~medrap.types.FusionInput`):
+        - ``patient_state``:    ``(B, S_ehr, D_ehr)``
+        - ``retrieval_memory``: ``(B, 1, K, S_doc, D_mem)``
+        - ``doc_attention_mask`` (optional): ``(B, 1, K, S_doc)`` bool, ``True`` = valid token
+
+    Output shape:
+        ``fused_state``: ``(B, K, d_model)``
+    """
+
+    produces_per_document_state = True
+
+    def __init__(
+        self,
+        *,
+        d_model: int,
+        num_heads: int,
+        ff_dim: int,
+        num_layers: int,
+        d_in_patient: int,
+        d_in_doc: int,
+        dropout: float = 0.0,
+    ) -> None:
+        super().__init__()
+        self.patient_proj = nn.Linear(d_in_patient, d_model)
+        self.layers = nn.ModuleList(
+            [_CrossAttentionLayer(d_model, d_in_doc, num_heads, ff_dim, dropout) for _ in range(num_layers)]
+        )
+        self.out_norm = nn.LayerNorm(d_model)
+
+    def fuse(self, fusion_input: FusionInput) -> FusionOutput:
+        """Enrich patient state by attending to each retrieved doc independently.
+
+        Args:
+            fusion_input: ``FusionInput`` with:
+
+                - ``patient_state`` shaped ``(B, S_ehr, D_ehr)``
+                - ``retrieval_memory`` shaped ``(B, 1, K, S_doc, D_mem)``
+                - ``doc_attention_mask`` optional bool mask ``(B, 1, K, S_doc)``
+
+        Returns:
+            ``FusionOutput`` where ``fused_state`` has shape ``(B, K, d_model)``.
+
+        Raises:
+            ValueError: If ``retrieval_memory`` is not 5-D or ``R != 1``.
+
+        Examples:
+            Basic forward pass — output is indexed by document, not sequence position:
+
+            >>> import torch
+            >>> from medrap.types import FusionInput
+            >>> fusion = PerDocCrossAttentionFusion(
+            ...     d_model=8,
+            ...     num_heads=2,
+            ...     ff_dim=16,
+            ...     num_layers=2,
+            ...     d_in_patient=4,
+            ...     d_in_doc=6,
+            ... )
+            >>> fi = FusionInput(
+            ...     patient_state=torch.randn(2, 10, 4),  # (B=2, S_ehr=10, D_ehr=4)
+            ...     retrieval_memory=torch.randn(2, 1, 3, 5, 6),  # (B, R=1, K=3, S_doc=5, D_mem=6)
+            ... )
+            >>> out = fusion.fuse(fi)
+            >>> tuple(out.fused_state.shape)
+            (2, 3, 8)
+
+            ``forward`` delegates to ``fuse``:
+
+            >>> tuple(fusion(fi).fused_state.shape)
+            (2, 3, 8)
+
+            Doc padding tokens are masked out of attention:
+
+            >>> mask = torch.ones(2, 1, 3, 5, dtype=torch.bool)
+            >>> mask[:, :, :, -1] = False  # last token of each doc is padding
+            >>> fi_masked = FusionInput(
+            ...     patient_state=torch.randn(2, 10, 4),
+            ...     retrieval_memory=torch.randn(2, 1, 3, 5, 6),
+            ...     doc_attention_mask=mask,
+            ... )
+            >>> tuple(fusion.fuse(fi_masked).fused_state.shape)
+            (2, 3, 8)
+
+            ``R != 1`` raises ``ValueError``:
+
+            >>> bad = FusionInput(
+            ...     patient_state=torch.randn(2, 10, 4),
+            ...     retrieval_memory=torch.randn(2, 2, 3, 5, 6),
+            ... )
+            >>> fusion.fuse(bad)  # doctest: +ELLIPSIS
+            Traceback (most recent call last):
+            ...
+            ValueError: PerDocCrossAttentionFusion only supports R=1...
+        """
+        ps = fusion_input.patient_state  # (B, S_ehr, D_ehr)
+        rm = fusion_input.retrieval_memory  # (B, R, K, S_doc, D_mem)
+
+        if rm.ndim != 5:
+            raise ValueError(
+                f"PerDocCrossAttentionFusion expects 5D retrieval_memory, got shape {tuple(rm.shape)}"
+            )
+        b, r, k, s_doc, d_mem = rm.shape
+        if r != 1:
+            raise ValueError(f"PerDocCrossAttentionFusion only supports R=1, got R={r}")
+
+        # Pair each patient with each of its K docs: [p0, p0, ..., p1, p1, ...] along dim 0.
+        ps_expanded = ps.repeat_interleave(k, dim=0)  # (B*K, S_ehr, D_ehr)
+        kv = rm.squeeze(1).reshape(b * k, s_doc, d_mem)  # (B*K, S_doc, D_mem)
+
+        key_padding_mask: torch.Tensor | None = None
+        if fusion_input.doc_attention_mask is not None:
+            flat_mask = fusion_input.doc_attention_mask.squeeze(1).reshape(b * k, s_doc).bool()
+            key_padding_mask = ~flat_mask  # True = padding (PyTorch convention)
+
+        x = self.patient_proj(ps_expanded)  # (B*K, S_ehr, d_model)
+        for layer in self.layers:
+            x = layer(x, kv, key_padding_mask)
+        x = self.out_norm(x)  # (B*K, S_ehr, d_model)
+
+        pooled = x.mean(dim=1)  # (B*K, d_model) — one vector per (patient, doc) pair
+        fused_state = pooled.reshape(b, k, -1)  # (B, K, d_model)
+
+        return FusionOutput(fused_state=fused_state)

--- a/src/medrap/model/fusion.py
+++ b/src/medrap/model/fusion.py
@@ -499,6 +499,17 @@ class PerDocCrossAttentionFusion(FusionModule):
             >>> tuple(fusion.fuse(fi_masked).fused_state.shape)
             (2, 3, 8)
 
+            Wrong ``retrieval_memory`` rank raises ``ValueError``:
+
+            >>> bad_rank = FusionInput(
+            ...     patient_state=torch.randn(2, 10, 4),
+            ...     retrieval_memory=torch.randn(2, 3, 6),
+            ... )
+            >>> fusion.fuse(bad_rank)  # doctest: +ELLIPSIS
+            Traceback (most recent call last):
+            ...
+            ValueError: PerDocCrossAttentionFusion expects 5D retrieval_memory...
+
             ``R != 1`` raises ``ValueError``:
 
             >>> bad = FusionInput(

--- a/src/medrap/model/model.py
+++ b/src/medrap/model/model.py
@@ -164,6 +164,36 @@ class RetrievalAugmentedModel(nn.Module):
             ... )
             tensor(True)
 
+        Marginalized retrieval with a fusion that attends to each document
+        independently (works at any K, unlike ``CrossAttentionFusion`` below):
+
+            >>> from medrap.model.fusion import PerDocCrossAttentionFusion
+            >>> from medrap.model.retrieval_encoder import TokenFeatureRetrievalEncoder
+            >>> m_perdoc = RetrievalAugmentedModel(
+            ...     encoder=MEDSCodeEncoder(),
+            ...     query_projector=SequenceMeanQueryProjector(in_dim=1, out_dim=4),
+            ...     retriever=InMemoryRetriever(
+            ...         doc_key_embeddings=torch.FloatTensor(
+            ...             [[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0]]
+            ...         ),
+            ...         doc_tokens=torch.LongTensor([[1, 2], [3, 4], [5, 6]]),
+            ...         doc_attention_mask=torch.BoolTensor([[True, True], [True, True], [True, True]]),
+            ...         k=2,
+            ...     ),
+            ...     retrieval_encoder=TokenFeatureRetrievalEncoder(vocab_size=8, embedding_dim=6),
+            ...     fusion=PerDocCrossAttentionFusion(
+            ...         d_model=4, num_heads=2, ff_dim=8, num_layers=1, d_in_patient=1, d_in_doc=6
+            ...     ),
+            ...     pooling=IdentityPooling(),
+            ...     head=LinearHead(in_dim=4, out_dim=2),
+            ...     marginalized_retrieval=True,
+            ... )
+            >>> out_perdoc = m_perdoc(mb)
+            >>> tuple(out_perdoc.logits.shape)
+            (2, 2)
+            >>> tuple(out_perdoc.metadata["per_doc_logits"].shape)
+            (2, 2, 2)
+
         Marginalized retrieval validation errors:
 
             >>> from unittest.mock import patch
@@ -197,6 +227,31 @@ class RetrievalAugmentedModel(nn.Module):
             Traceback (most recent call last):
             ...
             ValueError: marginalized_retrieval requires a LinearHead...
+            >>> from medrap.model.fusion import CrossAttentionFusion
+            >>> m_wrong_fusion = RetrievalAugmentedModel(
+            ...     encoder=MEDSCodeEncoder(),
+            ...     query_projector=SequenceMeanQueryProjector(in_dim=1, out_dim=4),
+            ...     retriever=InMemoryRetriever(
+            ...         doc_key_embeddings=torch.FloatTensor(
+            ...             [[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0]]
+            ...         ),
+            ...         doc_tokens=torch.LongTensor([[1, 2], [3, 4], [5, 6]]),
+            ...         doc_attention_mask=torch.BoolTensor([[True, True], [True, True], [True, True]]),
+            ...         k=2,
+            ...         similarity="dot",
+            ...     ),
+            ...     retrieval_encoder=TokenFeatureRetrievalEncoder(vocab_size=8, embedding_dim=4),
+            ...     fusion=CrossAttentionFusion(
+            ...         d_model=4, num_heads=2, ff_dim=8, num_layers=1, d_in_patient=1, d_in_doc=4
+            ...     ),
+            ...     pooling=IdentityPooling(),
+            ...     head=LinearHead(in_dim=4, out_dim=2),
+            ...     marginalized_retrieval=True,
+            ... )
+            >>> m_wrong_fusion(mb)  # doctest: +ELLIPSIS
+            Traceback (most recent call last):
+            ...
+            ValueError: ...fusion module...
             >>> class _NoKeyRet(nn.Module):
             ...     def forward(self, _q):
             ...         from medrap.types import RetrieverOutput  # types stays at top level
@@ -222,6 +277,8 @@ class RetrievalAugmentedModel(nn.Module):
             ...
             ValueError: ...doc_key_embeddings...
             >>> class _BadFus(nn.Module):
+            ...     produces_per_document_state = True
+            ...
             ...     def forward(self, fusion_input):
             ...         from medrap.types import FusionOutput  # types stays at top level
             ...
@@ -277,6 +334,13 @@ class RetrievalAugmentedModel(nn.Module):
         if self.marginalized_retrieval:
             if not isinstance(self.head, LinearHead):
                 raise ValueError("marginalized_retrieval requires a LinearHead for per-document logits")
+            if not getattr(self.fusion, "produces_per_document_state", False):
+                raise ValueError(
+                    "marginalized_retrieval requires a fusion module that produces per-document "
+                    f"fused_state (B, K, D); {type(self.fusion).__name__} does not "
+                    "(set produces_per_document_state=True on it, e.g. ReplaceFusion or "
+                    "PerDocCrossAttentionFusion)"
+                )
             if retrieval_out.doc_key_embeddings is None:
                 raise ValueError(
                     "marginalized_retrieval requires retriever outputs with doc_key_embeddings "


### PR DESCRIPTION
## Summary

Closes #64.

- **`CrossAttentionFusion`/`PassthroughFusion` silently broke `marginalized_retrieval=True`**: both return `fused_state` shaped `(B, S_ehr, D)`, which passes `RetrievalAugmentedModel`'s only guard (`fused.ndim == 3`) undetected. The model would then marginalize over EHR sequence positions instead of retrieved documents — wrong predictions and gradients with no error raised.
- **Add `PerDocCrossAttentionFusion`** (`model/fusion.py`): expands the batch to `B*K`, cross-attends each patient to exactly one of its retrieved documents, mean-pools over the patient sequence, and reshapes to `(B, K, d_model)` — the shape the marginalized-retrieval path actually requires, at any `K`. Exported from `medrap.__init__` and given a Hydra config (`conf/fusion/cross_attention_perdoc_medium.yaml`), matching `cross_attention_medium.yaml`'s conventions.
- **Close the compatibility gap explicitly**: added a `produces_per_document_state` flag on `FusionModule` (`False` by default, `True` on `ReplaceFusion` and the new `PerDocCrossAttentionFusion`). `RetrievalAugmentedModel.forward` now raises a clear `ValueError` when `marginalized_retrieval=True` is paired with a fusion that doesn't declare itself per-document-indexed, instead of silently computing wrong `per_doc_logits`.
- Added doctests in both `fusion.py` (shape/masking/`R != 1` validation for the new class) and `model.py` (end-to-end marginalized retrieval through `PerDocCrossAttentionFusion`, plus the new incompatible-fusion error path). Updated `README.md`'s fusion list and Hydra config-group list.

I found an existing branch (`random-prediction-time`, PR #50) with a `PerDocCrossAttentionFusion` implementation bundled together with unrelated random-prediction-time/null-document changes, predating the `model/`/`train/` subpackage reorganization. This PR reimplements just the fusion piece against the current module layout, and additionally adds the `model.py` guard so the original incompatibility is actually closed (not just worked around by offering an alternative).

## Test plan

- [x] `pytest tests/ src/medrap` — 217 passed (includes new doctests)
- [x] `pre-commit run --all-files` — clean
- [x] Manually composed the new Hydra config (`fusion=cross_attention_perdoc_medium`) via `hydra.compose` and confirmed it resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)