### PR TITLE
refactor: move prepare_retrieval_dataset_from_config to preparation.py, inline CLI helper

### DIFF
--- a/src/medrap/__init__.py
+++ b/src/medrap/__init__.py
@@ -8,7 +8,6 @@ from .configs import (
     RAPAppConfig,
     float_tensor_config,
     instantiate_model,
-    prepare_retrieval_dataset_from_config,
 )
 from .model.encoders import (
     MEDSCodeEncoder,
@@ -36,7 +35,11 @@ from .model.retrievers import (
     load_hf_dataset_retriever,
     load_in_memory_retriever,
 )
-from .prepare_retrieval.preparation import OrderedFieldDocumentRenderer, prepare_retrieval_dataset
+from .prepare_retrieval.preparation import (
+    OrderedFieldDocumentRenderer,
+    prepare_retrieval_dataset,
+    prepare_retrieval_dataset_from_config,
+)
 from .train.lightning_module import MedRAPSupervisedLightningModule
 from .train.losses import MultiTaskBCELoss, MultiTaskBCEMarginalizedLoss
 from .train.multitask_datamodule import MultiTaskMEDSDatamodule, MultiTaskMEDSDataset, load_code_index

--- a/src/medrap/cli.py
+++ b/src/medrap/cli.py
@@ -11,11 +11,8 @@ from hydra_zen import instantiate
 from lightning.pytorch.loggers import CSVLogger
 from omegaconf import DictConfig, OmegaConf
 
-from .configs import (
-    instantiate_datamodule,
-    instantiate_training_module,
-    prepare_retrieval_dataset_from_config,
-)
+from .configs import instantiate_datamodule, instantiate_training_module
+from .prepare_retrieval.preparation import prepare_retrieval_dataset_from_config
 from .preprocess.preprocessing import run_meds_pipeline
 from .preprocess.task_generation import generate_tasks
 
@@ -293,10 +290,6 @@ def _prepare_eval_run(cfg: DictConfig) -> Path:
     return output_dir
 
 
-def _prepare_retrieval_dataset_run(cfg: DictConfig) -> Path:
-    return _setup_output_dir(Path(cfg.prep.output.output_dir), cfg)
-
-
 def _ensure_lightning_csv_log_dirs(trainer: object) -> None:
     """Create CSVLogger ``log_dir`` trees before the first metrics flush.
 
@@ -392,14 +385,6 @@ def _run_eval(cfg: DictConfig) -> int:
     raise ValueError(f"eval_mode must be 'validate' or 'test'; got {cfg.eval_mode!r}")
 
 
-def _run_prepare_retrieval_dataset(cfg: DictConfig) -> int:
-    print(OmegaConf.to_yaml(cfg))
-    _prepare_retrieval_dataset_run(cfg)
-    output_path = prepare_retrieval_dataset_from_config(cfg)
-    print(f"Prepared retrieval dataset saved to {output_path}")
-    return 0
-
-
 @hydra.main(version_base=None, config_path="conf", config_name="_preprocess")
 def preprocess_main(cfg: DictConfig) -> None:
     """Run the Hydra-native MEDS preprocessing and task-generation entrypoint."""
@@ -431,6 +416,15 @@ def preprocess_main(cfg: DictConfig) -> None:
     print(f"Task labels saved to {tasks_out}")
 
 
+@hydra.main(version_base=None, config_path="conf", config_name="_prepare_retrieval_dataset")
+def prepare_retrieval_dataset_main(cfg: DictConfig) -> None:
+    """Run the Hydra-native retrieval-dataset preparation entrypoint."""
+    print(OmegaConf.to_yaml(cfg))
+    _setup_output_dir(Path(cfg.prep.output.output_dir), cfg)
+    output_path = prepare_retrieval_dataset_from_config(cfg)
+    print(f"Prepared retrieval dataset saved to {output_path}")
+
+
 @hydra.main(version_base=None, config_path="conf", config_name="_train")
 def train_main(cfg: DictConfig) -> int:
     """Run the Hydra-native training entrypoint."""
@@ -441,9 +435,3 @@ def train_main(cfg: DictConfig) -> int:
 def eval_main(cfg: DictConfig) -> int:
     """Run the Hydra-native evaluation entrypoint."""
     return _run_eval(cfg)
-
-
-@hydra.main(version_base=None, config_path="conf", config_name="_prepare_retrieval_dataset")
-def prepare_retrieval_dataset_main(cfg: DictConfig) -> int:
-    """Run the Hydra-native retrieval-dataset preparation entrypoint."""
-    return _run_prepare_retrieval_dataset(cfg)

--- a/src/medrap/configs.py
+++ b/src/medrap/configs.py
@@ -5,6 +5,7 @@ from concrete components.
 """
 
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, cast
 
 import lightning
@@ -18,6 +19,8 @@ from meds_torchdata import MEDSTorchBatch, MEDSTorchDataConfig
 from meds_torchdata.extensions.lightning_datamodule import Datamodule as MEDSLightningDatamodule
 from meds_torchdata.types import SubsequenceSamplingStrategy
 from omegaconf import MISSING, OmegaConf
+from sentence_transformers import SentenceTransformer
+from transformers import AutoTokenizer
 
 from .model.encoders import MEDSCodeEncoder, TokenEmbeddingEncoder
 from .model.fusion import ConcatFusion, ReplaceFusion
@@ -33,10 +36,7 @@ from .model.retrieval_encoder import (
     TokenFeatureRetrievalEncoder,
 )
 from .model.retrievers import InMemoryRetriever, load_hf_dataset_retriever
-from .prepare_retrieval.preparation import (
-    OrderedFieldDocumentRenderer,
-    prepare_retrieval_dataset,
-)
+from .prepare_retrieval.preparation import OrderedFieldDocumentRenderer
 from .train.datamodule import SyntheticSupervisedDatamodule
 from .train.lightning_module import MedRAPSupervisedLightningModule
 from .train.losses import MarginalizedRetrievalSupervisedLoss
@@ -231,17 +231,17 @@ OrderedFieldDocumentRendererConfig = builds_any(
 )
 
 
-@dataclass
-class HFTokenizerConfig:
-    _target_: str = "transformers.AutoTokenizer.from_pretrained"
-    pretrained_model_name_or_path: str = MISSING
-
-
-@dataclass
-class SentenceTransformerEmbedderConfig:
-    _target_: str = "sentence_transformers.SentenceTransformer"
-    model_name_or_path: str = MISSING
-    device: str = "cpu"
+HFTokenizerConfig = builds_any(
+    AutoTokenizer.from_pretrained,
+    pretrained_model_name_or_path=MISSING,
+    zen_dataclass={"cls_name": "HFTokenizerConfig"},
+)
+SentenceTransformerEmbedderConfig = builds_any(
+    SentenceTransformer,
+    model_name_or_path=MISSING,
+    device="cpu",
+    zen_dataclass={"cls_name": "SentenceTransformerEmbedderConfig"},
+)
 
 
 CSVLoggerConfig = builds_any(
@@ -561,150 +561,6 @@ def instantiate_training_module(config: RAPTrainConfig) -> MedRAPSupervisedLight
     task = instantiate_any(config.training.task)
     loss_fn = instantiate_any(config.training.loss)
     return instantiate_any(config.training.module, model=plain_model, task=task, loss_fn=loss_fn)
-
-
-def prepare_retrieval_dataset_from_config(config: Any) -> str:
-    """Prepare and save a static retrieval dataset artifact from config.
-
-    Args:
-        config: Structured config containing a ``prep`` section with source,
-            rendering, tokenizer, embedder, index, and output settings.
-
-    Returns:
-        Output directory path where the prepared dataset artifact was saved.
-
-    Examples:
-        >>> cfg = PrepareRetrievalDatasetAppConfig(
-        ...     prep=PrepareRetrievalDatasetConfig(
-        ...         output=RetrievalDatasetOutputConfig(output_dir="/tmp/prepared")
-        ...     )
-        ... )
-        >>> cfg.prep.index == RetrievalDatasetIndexConfig()
-        True
-        >>> cfg.prep.output.output_dir
-        '/tmp/prepared'
-        >>> cfg.do_overwrite
-        False
-        >>> retriever_cfg = HFDatasetRetrieverConfig(dataset_path="/tmp/retrieval-artifact")
-        >>> retriever_cfg.dataset_path
-        '/tmp/retrieval-artifact'
-        >>> retriever_cfg.index_name
-        'retrieval'
-
-    Delegation to :func:`medrap.preparation.prepare_retrieval_dataset` (smoke):
-
-        >>> from pathlib import Path
-        >>> from unittest.mock import patch
-        >>> captured = {}
-        >>> def _fake_prep(*_a, **kwargs):
-        ...     captured.clear()
-        ...     captured.update(kwargs)
-        ...     return "/tmp/prepared_out"
-        >>> import medrap.configs as _cfg_mod
-        >>> with (
-        ...     patch.object(_cfg_mod, "prepare_retrieval_dataset", _fake_prep),
-        ...     patch.object(_cfg_mod, "instantiate_any", lambda _c: object()),
-        ... ):
-        ...     artifact = Path("/tmp/artifact")
-        ...     cfg = PrepareRetrievalDatasetAppConfig(
-        ...         prep=PrepareRetrievalDatasetConfig(
-        ...             output=RetrievalDatasetOutputConfig(output_dir=str(artifact))
-        ...         )
-        ...     )
-        ...     r = prepare_retrieval_dataset_from_config(cfg)
-        >>> r == "/tmp/prepared_out" and captured.get("output_dir") == str(artifact)
-        True
-
-    ``num_docs`` applies a deterministic shuffle then takes the first ``num_docs`` rows:
-
-        >>> class _RecordingDataset:
-        ...     def __init__(self) -> None:
-        ...         self.shuffle_seed: int | None = None
-        ...
-        ...     def shuffle(self, seed: int = 42):
-        ...         self.shuffle_seed = int(seed)
-        ...         return self
-        ...
-        ...     def select(self, indices):
-        ...         return ("subset", self.shuffle_seed, list(indices))
-        >>> captured_subset = {}
-        >>> def _fake_prep_subset(*_a, **kwargs):
-        ...     captured_subset.clear()
-        ...     captured_subset.update(kwargs)
-        ...     return "/tmp/prepared_subset"
-        >>> _stubs_subset = [_RecordingDataset(), object(), object(), object()]
-        >>> def _fake_inst_subset(_cfg):
-        ...     return _stubs_subset.pop(0)
-        >>> with (
-        ...     patch.object(_cfg_mod, "prepare_retrieval_dataset", _fake_prep_subset),
-        ...     patch.object(_cfg_mod, "instantiate_any", _fake_inst_subset),
-        ... ):
-        ...     cfg_subset = PrepareRetrievalDatasetAppConfig(
-        ...         prep=PrepareRetrievalDatasetConfig(
-        ...             output=RetrievalDatasetOutputConfig(output_dir="/tmp/artifact_subset"),
-        ...             num_docs=3,
-        ...             num_docs_seed=9,
-        ...         )
-        ...     )
-        ...     _r_subset = prepare_retrieval_dataset_from_config(cfg_subset)
-        >>> _r_subset == "/tmp/prepared_subset"
-        True
-        >>> captured_subset["dataset"]
-        ('subset', 9, [0, 1, 2])
-
-    Full unmocked round trip — a real dataset saved to disk, loaded via
-    :class:`LoadHFDatasetFromDiskConfig`, and prepared through the real
-    ``instantiate_any`` wiring (no mocking):
-
-        >>> from datasets import Dataset
-        >>> from hydra_zen import builds
-        >>> TokenizerConfig = builds(DoctestTokenizer, populate_full_signature=False)
-        >>> EmbedderConfig = builds(DoctestEmbedder, populate_full_signature=False)
-        >>> with tempfile.TemporaryDirectory() as tmpdir:
-        ...     source_path = Path(tmpdir) / "source"
-        ...     Dataset.from_dict({"text": ["alpha", "beta"]}).save_to_disk(str(source_path))
-        ...     real_cfg = PrepareRetrievalDatasetAppConfig(
-        ...         prep=PrepareRetrievalDatasetConfig(
-        ...             source=LoadHFDatasetFromDiskConfig(dataset_path=str(source_path)),
-        ...             document=OrderedFieldDocumentRendererConfig(fields=["text"]),
-        ...             tokenizer=TokenizerConfig(),
-        ...             embedder=EmbedderConfig(),
-        ...             index=RetrievalDatasetIndexConfig(max_length=4),
-        ...             output=RetrievalDatasetOutputConfig(output_dir=str(Path(tmpdir) / "prepared")),
-        ...         )
-        ...     )
-        ...     real_output_dir = prepare_retrieval_dataset_from_config(real_cfg)
-        ...     (Path(real_output_dir) / "retrieval.faiss").exists()
-        True
-    """
-    prep_cfg = config.prep
-    dataset = instantiate_any(prep_cfg.source)
-    if prep_cfg.num_docs is not None:
-        dataset = dataset.shuffle(seed=int(prep_cfg.num_docs_seed)).select(range(int(prep_cfg.num_docs)))
-    renderer = instantiate_any(prep_cfg.document)
-    tokenizer = instantiate_any(prep_cfg.tokenizer)
-    embedder = instantiate_any(prep_cfg.embedder)
-
-    output_path = prepare_retrieval_dataset(
-        dataset=dataset,
-        renderer=renderer,
-        tokenizer=tokenizer,
-        embedder=embedder,
-        output_dir=prep_cfg.output.output_dir,
-        doc_text_column=prep_cfg.index.doc_text_column,
-        doc_tokens_column=prep_cfg.index.doc_tokens_column,
-        doc_attention_mask_column=prep_cfg.index.doc_attention_mask_column,
-        doc_key_embeddings_column=prep_cfg.index.doc_key_embeddings_column,
-        doc_ids_column=prep_cfg.index.doc_ids_column,
-        source_id_column=prep_cfg.index.source_id_column,
-        index_name=prep_cfg.index.index_name,
-        max_length=prep_cfg.index.max_length,
-        tokenization_batch_size=prep_cfg.index.tokenization_batch_size,
-        embedding_batch_size=prep_cfg.index.embedding_batch_size,
-        encode_batch_size=prep_cfg.index.encode_batch_size,
-        string_factory=prep_cfg.index.string_factory,
-    )
-    return str(output_path)
 
 
 @dataclass

--- a/src/medrap/configs.py
+++ b/src/medrap/configs.py
@@ -5,7 +5,6 @@ from concrete components.
 """
 
 from dataclasses import dataclass, field
-from pathlib import Path
 from typing import Any, cast
 
 import lightning

--- a/src/medrap/prepare_retrieval/README.md
+++ b/src/medrap/prepare_retrieval/README.md
@@ -1,6 +1,114 @@
 # medrap.prepare_retrieval
 
-Offline preparation for the `medrap-prepare-retrieval-dataset` command. Takes a Hugging Face
-dataset of text documents, renders them into a fixed field order, tokenizes and embeds them
-using a pretrained encoder, and writes out a FAISS index for nearest-neighbor retrieval at
-training and inference time.
+`medrap-prepare-retrieval-dataset` is a single CLI command that takes a
+Hugging Face dataset of text documents and produces a static retrieval artifact:
+a tokenized, embedded dataset saved to disk with a FAISS nearest-neighbor index.
+The artifact is what `HFDatasetRetriever` loads at training and inference time.
+
+## How to run
+
+```bash
+medrap-prepare-retrieval-dataset \
+  prep.source.path=<hf-dataset-name-or-path> \
+  prep.source.split=<split> \
+  "prep.document.fields=[<col1>,<col2>]" \
+  prep.tokenizer.pretrained_model_name_or_path=<model> \
+  prep.embedder.model_name_or_path=<model> \
+  prep.output.output_dir=<path/to/output>
+```
+
+### Example — MedRAG/textbooks, 10 docs
+
+```bash
+medrag-prepare-retrieval-dataset \
+  prep.source.path=MedRAG/textbooks \
+  prep.source.split=train \
+  "prep.document.fields=[title,content]" \
+  prep.index.source_id_column=id \
+  prep.tokenizer.pretrained_model_name_or_path=sentence-transformers/all-MiniLM-L6-v2 \
+  prep.embedder.model_name_or_path=sentence-transformers/all-MiniLM-L6-v2 \
+  prep.embedder.device=cpu \
+  prep.output.output_dir=./retrieval_dataset \
+  prep.num_docs=10
+```
+
+### Key options
+
+| Option                               | Default      | Description                                                                                                                     |
+| ------------------------------------ | ------------ | ------------------------------------------------------------------------------------------------------------------------------- |
+| `prep.document.fields`               | **required** | Ordered list of source columns to concatenate into document text                                                                |
+| `prep.document.separator`            | `\n`         | String inserted between rendered field fragments                                                                                |
+| `prep.document.include_field_names`  | `false`      | Prefix each field value with `"<field>: "`                                                                                      |
+| `prep.index.source_id_column`        | `null`       | Source column to use as `doc_ids`; falls back to row index when `null`                                                          |
+| `prep.index.max_length`              | 512          | Tokenizer max sequence length (truncates longer documents)                                                                      |
+| `prep.index.tokenization_batch_size` | 256          | Batch size for the tokenization map pass                                                                                        |
+| `prep.index.embedding_batch_size`    | 256          | Outer batch size passed to `dataset.map` during embedding                                                                       |
+| `prep.index.encode_batch_size`       | `null`       | Per-forward-pass batch size inside `embedder.encode`; defaults to `embedding_batch_size` — lower this to reduce peak GPU memory |
+| `prep.index.string_factory`          | `null`       | FAISS `string_factory` for non-flat indexes (e.g. `"IVF256,Flat"`)                                                              |
+| `prep.num_docs`                      | `null`       | Randomly subsample this many docs before processing; `null` uses all                                                            |
+| `prep.num_docs_seed`                 | 42           | Random seed for subsampling                                                                                                     |
+| `prep.embedder.device`               | `cpu`        | Device for embedding (`cpu`, `cuda`, `mps`)                                                                                     |
+| `do_overwrite`                       | `false`      | Overwrite an existing output directory                                                                                          |
+
+### Loading from disk instead of Hugging Face Hub
+
+To use a locally saved dataset, switch the source config group:
+
+```bash
+medrap-prepare-retrieval-dataset \
+  prep/source=load_from_disk \
+  prep.source.dataset_path=<path/to/local/dataset> \
+  ...
+```
+
+## What happens under the hood
+
+### Stage 1 — Document rendering
+
+Each row in the source dataset is passed through `OrderedFieldDocumentRenderer`,
+which concatenates the configured `fields` in order, joined by `separator`. The
+result is written to the `doc_text` column. If `source_id_column` is set, its
+value is copied into `doc_ids`; otherwise the row index is used.
+
+### Stage 2 — Tokenization
+
+`doc_text` is tokenized with the configured `AutoTokenizer` using truncation and
+`max_length` padding. Token ids and attention masks are written to `doc_tokens`
+and `doc_attention_mask`. These are the inputs loaded by the retrieval encoder
+at training time.
+
+### Stage 3 — Embedding
+
+`doc_text` is encoded by the configured `SentenceTransformer` embedder. The
+resulting float32 vectors are written to `doc_key_embeddings`. These are the
+vectors indexed by FAISS and used to score query-document similarity at
+retrieval time.
+
+### Stage 4 — FAISS indexing
+
+A FAISS flat L2 index (or the index described by `string_factory`) is built
+over `doc_key_embeddings`. The index is saved as `<index_name>.faiss` alongside
+the dataset. The embeddings column is kept in the dataset for payload
+access during retrieval.
+
+## Output layout
+
+```
+<output_dir>/
+  config.yaml            # raw Hydra config as passed
+  resolved_config.yaml   # fully resolved config (all interpolations expanded)
+  data-00000-of-N.arrow  # tokenized + embedded dataset (Arrow format)
+  dataset_info.json      # Hugging Face dataset metadata
+  state.json             # Hugging Face dataset state
+  retrieval.faiss        # FAISS index over doc_key_embeddings
+```
+
+The directory is consumed directly by `HFDatasetRetrieverConfig`:
+
+```yaml
+retriever:
+  _target_: medrap.model.retrievers.load_hf_dataset_retriever
+  dataset_path: <output_dir>
+  index_name: retrieval
+  k: 4
+```

--- a/src/medrap/prepare_retrieval/preparation.py
+++ b/src/medrap/prepare_retrieval/preparation.py
@@ -230,7 +230,7 @@ def prepare_retrieval_dataset_from_config(cfg: "DictConfig") -> Path:
     """
     prep = cfg.prep
     dataset = instantiate(prep.source)
-    if cfg.get("num_docs") is not None:
+    if prep.num_docs is not None:
         dataset = dataset.shuffle(seed=prep.num_docs_seed).select(range(prep.num_docs))
     return prepare_retrieval_dataset(
         dataset=dataset,
@@ -238,5 +238,5 @@ def prepare_retrieval_dataset_from_config(cfg: "DictConfig") -> Path:
         tokenizer=instantiate(prep.tokenizer),
         embedder=instantiate(prep.embedder),
         output_dir=prep.output.output_dir,
-        **{k: v for k, v in prep.index.items()},
+        **dict(prep.index),
     )

--- a/src/medrap/prepare_retrieval/preparation.py
+++ b/src/medrap/prepare_retrieval/preparation.py
@@ -227,6 +227,59 @@ def prepare_retrieval_dataset_from_config(cfg: "DictConfig") -> Path:
 
     Returns:
         Output directory containing the saved dataset artifact and FAISS index.
+
+    Examples:
+        >>> from datasets import Dataset
+        >>> from hydra_zen import builds
+        >>> from medrap.configs import (
+        ...     LoadHFDatasetFromDiskConfig,
+        ...     OrderedFieldDocumentRendererConfig,
+        ...     PrepareRetrievalDatasetAppConfig,
+        ...     PrepareRetrievalDatasetConfig,
+        ...     RetrievalDatasetIndexConfig,
+        ...     RetrievalDatasetOutputConfig,
+        ... )
+        >>> TokenizerCfg = builds(DoctestTokenizer, populate_full_signature=False)
+        >>> EmbedderCfg = builds(DoctestEmbedder, populate_full_signature=False)
+        >>> with tempfile.TemporaryDirectory() as tmpdir:
+        ...     src = Path(tmpdir) / "source"
+        ...     Dataset.from_dict({"text": ["alpha", "beta"]}).save_to_disk(str(src))
+        ...     cfg = OmegaConf.structured(
+        ...         PrepareRetrievalDatasetAppConfig(
+        ...             prep=PrepareRetrievalDatasetConfig(
+        ...                 source=LoadHFDatasetFromDiskConfig(dataset_path=str(src)),
+        ...                 document=OrderedFieldDocumentRendererConfig(fields=["text"]),
+        ...                 tokenizer=TokenizerCfg(),
+        ...                 embedder=EmbedderCfg(),
+        ...                 index=RetrievalDatasetIndexConfig(max_length=4),
+        ...                 output=RetrievalDatasetOutputConfig(output_dir=str(Path(tmpdir) / "prepared")),
+        ...             )
+        ...         )
+        ...     )
+        ...     out = prepare_retrieval_dataset_from_config(cfg)
+        ...     (Path(str(out)) / "retrieval.faiss").exists()
+        True
+        >>> with tempfile.TemporaryDirectory() as tmpdir:
+        ...     src = Path(tmpdir) / "source"
+        ...     Dataset.from_dict({"text": ["alpha", "beta", "gamma"]}).save_to_disk(str(src))
+        ...     cfg = OmegaConf.structured(
+        ...         PrepareRetrievalDatasetAppConfig(
+        ...             prep=PrepareRetrievalDatasetConfig(
+        ...                 source=LoadHFDatasetFromDiskConfig(dataset_path=str(src)),
+        ...                 document=OrderedFieldDocumentRendererConfig(fields=["text"]),
+        ...                 tokenizer=TokenizerCfg(),
+        ...                 embedder=EmbedderCfg(),
+        ...                 index=RetrievalDatasetIndexConfig(max_length=4),
+        ...                 output=RetrievalDatasetOutputConfig(output_dir=str(Path(tmpdir) / "prepared")),
+        ...                 num_docs=2,
+        ...             )
+        ...         )
+        ...     )
+        ...     out = prepare_retrieval_dataset_from_config(cfg)
+        ...     from datasets import load_from_disk
+        ...
+        ...     len(load_from_disk(str(out)))
+        2
     """
     prep = cfg.prep
     dataset = instantiate(prep.source)

--- a/src/medrap/prepare_retrieval/preparation.py
+++ b/src/medrap/prepare_retrieval/preparation.py
@@ -2,10 +2,14 @@
 
 from collections.abc import Mapping, Sequence
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 from datasets import Dataset
+from hydra_zen import instantiate
+
+if TYPE_CHECKING:
+    from omegaconf import DictConfig
 
 
 class OrderedFieldDocumentRenderer:
@@ -213,3 +217,26 @@ def prepare_retrieval_dataset(
     prepared.drop_index(index_name)
     prepared.save_to_disk(str(output_path))
     return output_path
+
+
+def prepare_retrieval_dataset_from_config(cfg: "DictConfig") -> Path:
+    """Prepare a retrieval dataset artifact from a Hydra config.
+
+    Args:
+        cfg: Top-level ``PrepareRetrievalDatasetAppConfig`` OmegaConf node.
+
+    Returns:
+        Output directory containing the saved dataset artifact and FAISS index.
+    """
+    prep = cfg.prep
+    dataset = instantiate(prep.source)
+    if cfg.get("num_docs") is not None:
+        dataset = dataset.shuffle(seed=prep.num_docs_seed).select(range(prep.num_docs))
+    return prepare_retrieval_dataset(
+        dataset=dataset,
+        renderer=instantiate(prep.document),
+        tokenizer=instantiate(prep.tokenizer),
+        embedder=instantiate(prep.embedder),
+        output_dir=prep.output.output_dir,
+        **{k: v for k, v in prep.index.items()},
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -105,6 +105,7 @@ def test_prepare_retrieval_dataset_entrypoint_runs_with_hydra_overrides(monkeypa
         captured["device"] = cfg.prep.embedder.device
         captured["output_dir"] = cfg.prep.output.output_dir
         captured["max_length"] = cfg.prep.index.max_length
+        return output_dir
 
     monkeypatch.setattr(
         "medrap.cli.prepare_retrieval_dataset_from_config", _fake_prepare_retrieval_dataset_from_config


### PR DESCRIPTION
## Summary

- `prepare_retrieval_dataset_from_config` moves from `configs.py` to `prepare_retrieval/preparation.py` — execution helpers belong with their pipeline module, not in the config/instantiation layer
- `HFTokenizerConfig` / `SentenceTransformerEmbedderConfig` converted from plain dataclasses to `builds_any(...)` for consistency with every other config in the file
- `_run_prepare_retrieval_dataset` deleted; its 4 lines inlined directly into `prepare_retrieval_dataset_main`, matching the flat `preprocess_main` pattern (the private helper had no direct tests and the indirection added no value)
- `__init__.py` import updated to pull from `prepare_retrieval.preparation` instead of `configs`

## Test plan

- [ ] `uv run pytest tests/test_cli.py` — 28 passed