### PR TITLE
refactor(train): clean up cli, task, loss, and lightning_module

### DIFF
--- a/src/medrap/__init__.py
+++ b/src/medrap/__init__.py
@@ -7,7 +7,6 @@ from .configs import (
     PrepareRetrievalDatasetConfig,
     RAPAppConfig,
     float_tensor_config,
-    instantiate_model,
 )
 from .model.encoders import (
     MEDSCodeEncoder,
@@ -41,9 +40,15 @@ from .prepare_retrieval.preparation import (
     prepare_retrieval_dataset_from_config,
 )
 from .train.lightning_module import MedRAPSupervisedLightningModule
-from .train.losses import MultiTaskBCELoss, MultiTaskBCEMarginalizedLoss
+from .train.losses import (
+    BinaryClassificationLoss,
+    MarginalizedRetrievalLoss,
+    MarginalizedRetrievalSupervisedLoss,
+    MultiTaskBCELoss,
+    MultiTaskBCEMarginalizedLoss,
+)
 from .train.multitask_datamodule import MultiTaskMEDSDatamodule, MultiTaskMEDSDataset, load_code_index
-from .train.task import BinaryClassificationLoss, BinaryClassificationTask, MultiTaskBinaryClassificationTask
+from .train.task import BinaryClassificationTask, MultiTaskBinaryClassificationTask
 from .types import (
     EncoderOutput,
     FusionInput,
@@ -73,6 +78,8 @@ __all__ = [
     "LinearProjectionRetrievalEncoder",
     "LinearQueryProjector",
     "MEDSCodeEncoder",
+    "MarginalizedRetrievalLoss",
+    "MarginalizedRetrievalSupervisedLoss",
     "MaskedMeanPooling",
     "MedRAPSupervisedLightningModule",
     "ModelOutput",
@@ -103,7 +110,6 @@ __all__ = [
     "TimeDeltaRoPEPatientEncoder",
     "TokenEmbeddingEncoder",
     "float_tensor_config",
-    "instantiate_model",
     "load_code_index",
     "load_hf_dataset_retriever",
     "load_in_memory_retriever",

--- a/src/medrap/cli.py
+++ b/src/medrap/cli.py
@@ -11,10 +11,10 @@ from hydra_zen import instantiate
 from lightning.pytorch.loggers import CSVLogger
 from omegaconf import DictConfig, OmegaConf
 
-from .configs import instantiate_datamodule, instantiate_training_module
 from .prepare_retrieval.preparation import prepare_retrieval_dataset_from_config
 from .preprocess.preprocessing import run_meds_pipeline
 from .preprocess.task_generation import generate_tasks
+from .train.factory import instantiate_training_module
 
 
 def _save_resolved(cfg: DictConfig, output_path: Path) -> None:
@@ -210,8 +210,11 @@ def _setup_output_dir(output_dir: Path, cfg: DictConfig) -> Path:
     return output_dir
 
 
-def _prepare_train_run(cfg: DictConfig) -> Path | None:
+def _prepare_train_run(cfg: DictConfig) -> tuple[Path, Path | None]:
     """Create or validate a training run directory.
+
+    Returns:
+        Tuple of (output_dir, ckpt_path). ckpt_path is set only when resuming.
 
     Examples:
         >>> with tempfile.TemporaryDirectory() as tmpdir:
@@ -228,7 +231,8 @@ def _prepare_train_run(cfg: DictConfig) -> Path | None:
         ...             "training": {"trainer": {"default_root_dir": "."}},
         ...         }
         ...     )
-        ...     _prepare_train_run(cfg) is None
+        ...     out_dir, ckpt = _prepare_train_run(cfg)
+        ...     ckpt is None
         True
         >>> stale_file.exists()
         False
@@ -271,7 +275,7 @@ def _prepare_train_run(cfg: DictConfig) -> Path | None:
         OmegaConf.save(cfg, config_path)
         _save_resolved_config(cfg, output_dir / "resolved_config.yaml")
 
-    return ckpt_path
+    return output_dir, ckpt_path
 
 
 def _prepare_eval_run(cfg: DictConfig) -> Path:
@@ -347,42 +351,8 @@ def _load_training_module_checkpoint(cfg: DictConfig, checkpoint_path: str) -> o
     return module
 
 
-def _run_train(cfg: DictConfig) -> int:
-    print(OmegaConf.to_yaml(cfg))
-    lightning.seed_everything(cfg.seed, workers=True)
-    output_dir = _prepare_output_dir(cfg)
-    ckpt_path = _prepare_train_run(cfg)
-    module = instantiate_training_module(cfg)
-    bound_cfg = _bind_trainer_paths(cfg, output_dir=output_dir)
-    trainer = instantiate(bound_cfg.training.trainer)
-    _ensure_lightning_csv_log_dirs(trainer)
-    datamodule = instantiate_datamodule(cfg)
-
-    trainer.fit(module, datamodule=datamodule, ckpt_path=str(ckpt_path) if ckpt_path else None)
-    _copy_best_checkpoint(trainer, output_dir)
-    return 0
-
-
-def _run_eval(cfg: DictConfig) -> int:
-    print(OmegaConf.to_yaml(cfg))
-    output_dir = _prepare_eval_run(cfg)
-    checkpoint_path = cfg.checkpoint_path
-    if not checkpoint_path:
-        raise ValueError("checkpoint_path must be set for medrap-eval.")
-
-    module = _load_training_module_checkpoint(cfg, checkpoint_path)
-    bound_cfg = _bind_trainer_paths(cfg, output_dir=output_dir)
-    trainer = instantiate(bound_cfg.training.trainer)
-    _ensure_lightning_csv_log_dirs(trainer)
-    datamodule = instantiate_datamodule(cfg)
-
-    if cfg.eval_mode == "validate":
-        trainer.validate(module, datamodule=datamodule)
-        return 0
-    if cfg.eval_mode == "test":
-        trainer.test(module, datamodule=datamodule)
-        return 0
-    raise ValueError(f"eval_mode must be 'validate' or 'test'; got {cfg.eval_mode!r}")
+def _instantiate_datamodule(cfg: DictConfig) -> object:
+    return instantiate(cfg.training.datamodule)
 
 
 @hydra.main(version_base=None, config_path="conf", config_name="_preprocess")
@@ -426,12 +396,37 @@ def prepare_retrieval_dataset_main(cfg: DictConfig) -> None:
 
 
 @hydra.main(version_base=None, config_path="conf", config_name="_train")
-def train_main(cfg: DictConfig) -> int:
+def train_main(cfg: DictConfig) -> None:
     """Run the Hydra-native training entrypoint."""
-    return _run_train(cfg)
+    print(OmegaConf.to_yaml(cfg))
+    lightning.seed_everything(cfg.seed, workers=True)
+    output_dir, ckpt_path = _prepare_train_run(cfg)
+    module = instantiate_training_module(cfg)
+    bound_cfg = _bind_trainer_paths(cfg, output_dir=output_dir)
+    trainer = instantiate(bound_cfg.training.trainer)
+    _ensure_lightning_csv_log_dirs(trainer)
+    datamodule = _instantiate_datamodule(cfg)
+    trainer.fit(module, datamodule=datamodule, ckpt_path=str(ckpt_path) if ckpt_path else None)
+    _copy_best_checkpoint(trainer, output_dir)
 
 
 @hydra.main(version_base=None, config_path="conf", config_name="_eval")
 def eval_main(cfg: DictConfig) -> int:
     """Run the Hydra-native evaluation entrypoint."""
-    return _run_eval(cfg)
+    print(OmegaConf.to_yaml(cfg))
+    output_dir = _prepare_eval_run(cfg)
+    checkpoint_path = cfg.checkpoint_path
+    if not checkpoint_path:
+        raise ValueError("checkpoint_path must be set for medrap-eval.")
+    module = _load_training_module_checkpoint(cfg, checkpoint_path)
+    bound_cfg = _bind_trainer_paths(cfg, output_dir=output_dir)
+    trainer = instantiate(bound_cfg.training.trainer)
+    _ensure_lightning_csv_log_dirs(trainer)
+    datamodule = _instantiate_datamodule(cfg)
+    if cfg.eval_mode == "validate":
+        trainer.validate(module, datamodule=datamodule)
+        return 0
+    if cfg.eval_mode == "test":
+        trainer.test(module, datamodule=datamodule)
+        return 0
+    raise ValueError(f"eval_mode must be 'validate' or 'test'; got {cfg.eval_mode!r}")

--- a/src/medrap/conf/training/loss/binary_bce.yaml
+++ b/src/medrap/conf/training/loss/binary_bce.yaml
@@ -1,1 +1,1 @@
-_target_: medrap.train.task.BinaryClassificationLoss
+_target_: medrap.train.losses.BinaryClassificationLoss

--- a/src/medrap/configs.py
+++ b/src/medrap/configs.py
@@ -17,14 +17,13 @@ from lightning.pytorch.loggers import CSVLogger
 from meds_torchdata import MEDSTorchBatch, MEDSTorchDataConfig
 from meds_torchdata.extensions.lightning_datamodule import Datamodule as MEDSLightningDatamodule
 from meds_torchdata.types import SubsequenceSamplingStrategy
-from omegaconf import MISSING, OmegaConf
+from omegaconf import MISSING
 from sentence_transformers import SentenceTransformer
 from transformers import AutoTokenizer
 
 from .model.encoders import MEDSCodeEncoder, TokenEmbeddingEncoder
 from .model.fusion import ConcatFusion, ReplaceFusion
 from .model.heads import LinearHead
-from .model.model import RetrievalAugmentedModel
 from .model.pooling import IdentityPooling, MaskedMeanPooling
 from .model.query_projection import LinearQueryProjector, SequenceMeanQueryProjector
 from .model.retrieval_encoder import (
@@ -38,9 +37,8 @@ from .model.retrievers import InMemoryRetriever, load_hf_dataset_retriever
 from .prepare_retrieval.preparation import OrderedFieldDocumentRenderer
 from .train.datamodule import SyntheticSupervisedDatamodule
 from .train.lightning_module import MedRAPSupervisedLightningModule
-from .train.losses import MarginalizedRetrievalSupervisedLoss
+from .train.losses import BinaryClassificationLoss, MarginalizedRetrievalSupervisedLoss
 from .train.task import (
-    BinaryClassificationLoss,
     BinaryClassificationTask,
     MarginalizedBinaryClassificationTask,
 )
@@ -451,117 +449,6 @@ class PrepareRetrievalDatasetAppConfig:
     do_overwrite: bool = False
 
 
-def instantiate_model(config: Any) -> RetrievalAugmentedModel:
-    """Instantiate a ``RetrievalAugmentedModel`` from structured config.
-
-    Examples:
-        >>> model = instantiate_model(PipelineConfig())
-        >>> names = (
-        ...     model.encoder.__class__.__name__,
-        ...     model.query_projector.__class__.__name__,
-        ...     model.retriever.__class__.__name__,
-        ...     model.retrieval_encoder.__class__.__name__,
-        ...     model.fusion.__class__.__name__,
-        ...     model.pooling.__class__.__name__,
-        ...     model.head.__class__.__name__,
-        ... )
-        >>> names == (
-        ...     "MEDSCodeEncoder",
-        ...     "SequenceMeanQueryProjector",
-        ...     "InMemoryRetriever",
-        ...     "MeanPooledRetrievalEncoder",
-        ...     "ReplaceFusion",
-        ...     "IdentityPooling",
-        ...     "LinearHead",
-        ... )
-        True
-        >>> model = instantiate_model(
-        ...     PipelineConfig(
-        ...         encoder=TokenEmbeddingEncoderConfig(vocab_size=32, embedding_dim=3),
-        ...         query_projector=LinearQueryProjectorConfig(in_dim=3, out_dim=2),
-        ...         retriever=InMemoryRetrieverConfig(
-        ...             doc_key_embeddings=float_tensor_config([[1.0, 0.0], [0.0, 1.0]]),
-        ...             doc_tokens=long_tensor_config([[9, 8, 0], [7, 6, 0]]),
-        ...             doc_attention_mask=bool_tensor_config([[True, True, False], [True, True, False]]),
-        ...         ),
-        ...         fusion=ConcatFusionConfig(),
-        ...         pooling=MaskedMeanPoolingConfig(),
-        ...         head=LinearHeadConfig(in_dim=5, out_dim=2),
-        ...     )
-        ... )
-        >>> (
-        ...     model.encoder.__class__.__name__,
-        ...     model.query_projector.__class__.__name__,
-        ...     model.fusion.__class__.__name__,
-        ...     model.pooling.__class__.__name__,
-        ...     model.head.__class__.__name__,
-        ... )
-        ('TokenEmbeddingEncoder', 'LinearQueryProjector', 'ConcatFusion', 'MaskedMeanPooling', 'LinearHead')
-        >>> model.head.linear.in_features
-        5
-    """
-    if OmegaConf.is_config(config):
-        marginalized_retrieval = bool(OmegaConf.select(config, "marginalized_retrieval", default=False))
-        marginalized_score_similarity = str(
-            OmegaConf.select(config, "marginalized_score_similarity", default="dot")
-        )
-    else:
-        marginalized_retrieval = bool(getattr(config, "marginalized_retrieval", False))
-        marginalized_score_similarity = str(getattr(config, "marginalized_score_similarity", "dot"))
-    return RetrievalAugmentedModel(
-        encoder=instantiate_any(config.encoder),
-        query_projector=instantiate_any(config.query_projector),
-        retriever=instantiate_any(config.retriever),
-        retrieval_encoder=instantiate_any(config.retrieval_encoder),
-        fusion=instantiate_any(config.fusion),
-        pooling=instantiate_any(config.pooling),
-        head=instantiate_any(config.head),
-        marginalized_retrieval=marginalized_retrieval,
-        marginalized_score_similarity=marginalized_score_similarity,
-    )
-
-
-def instantiate_training_module(config: RAPTrainConfig) -> MedRAPSupervisedLightningModule:
-    """Instantiate the configured training wrapper around the plain RAP model.
-
-    Args:
-        config: Training config containing the plain RAP model composition under the
-            top-level pipeline fields and the supervised wrapper/task under
-            ``config.training``.
-
-    Returns:
-        MedRAPSupervisedLightningModule: Lightning wrapper whose plain model returns
-        logits shaped ``(B, config.training.task.output_dim)`` for a batch of size
-        ``B``.
-
-    Examples:
-        >>> module = instantiate_training_module(RAPTrainConfig(output_dir="outputs/demo"))
-        >>> module.__class__.__name__
-        'MedRAPSupervisedLightningModule'
-        >>> module.task.output_dim
-        1
-        >>> module.loss_fn.__class__.__name__
-        'BinaryClassificationLoss'
-        >>> batch = MEDSTorchBatch(
-        ...     code=torch.LongTensor([[101, 7, 0], [42, 3, 0]]),
-        ...     numeric_value=torch.FloatTensor([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]),
-        ...     numeric_value_mask=torch.BoolTensor([[False, False, False], [False, False, False]]),
-        ...     time_delta_days=torch.FloatTensor([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]),
-        ...     boolean_value=torch.BoolTensor([True, False]),
-        ... )
-        >>> out = module.model.forward(batch)
-        >>> tuple(out.logits.shape)
-        (2, 1)
-        >>> targets = module.task.extract_targets(batch)
-        >>> module.loss_fn(out, targets).ndim
-        0
-    """
-    plain_model = instantiate_model(config)
-    task = instantiate_any(config.training.task)
-    loss_fn = instantiate_any(config.training.loss)
-    return instantiate_any(config.training.module, model=plain_model, task=task, loss_fn=loss_fn)
-
-
 @dataclass
 class PreprocessDatasetAppConfig:
     """Top-level app config for the medrap-preprocess pipeline.
@@ -585,24 +472,3 @@ class PreprocessDatasetAppConfig:
     do_overwrite: bool = False
 
 
-def instantiate_datamodule(config: RAPTrainConfig | RAPEvalConfig) -> lightning.LightningDataModule:
-    """Instantiate the configured training datamodule.
-
-    Args:
-        config: Execution config containing datamodule settings under
-            ``config.training.datamodule``.
-
-    Returns:
-        lightning.LightningDataModule: Configured datamodule yielding ``MEDSTorchBatch``.
-
-    Examples:
-        >>> datamodule = instantiate_datamodule(
-        ...     RAPTrainConfig(
-        ...         output_dir="outputs/demo",
-        ...         training=TrainingConfig(datamodule=SyntheticSupervisedDatamoduleConfig()),
-        ...     )
-        ... )
-        >>> datamodule.__class__.__name__
-        'SyntheticSupervisedDatamodule'
-    """
-    return instantiate_any(config.training.datamodule)

--- a/src/medrap/configs.py
+++ b/src/medrap/configs.py
@@ -470,5 +470,3 @@ class PreprocessDatasetAppConfig:
     min_history_days: float = 1.0
     seed: int = 42
     do_overwrite: bool = False
-
-

--- a/src/medrap/train/callbacks.py
+++ b/src/medrap/train/callbacks.py
@@ -13,37 +13,7 @@ from torch import Tensor
 from torchmetrics.functional.classification import binary_auroc
 
 from ..types import ModelOutput
-
-
-def _positive_class_probs(logits: Tensor) -> Tensor:
-    """Map binary logits to probabilities of the positive class (shape ``(N,)``).
-
-    Examples:
-        >>> import torch
-        >>> p = _positive_class_probs(torch.tensor([[0.0, 1.0], [1.0, 0.0]]))
-        >>> tuple(p.shape)
-        (2,)
-        >>> bool(p[0] > p[1])
-        True
-        >>> p1 = _positive_class_probs(torch.tensor([[0.0], [2.0]]))
-        >>> bool(p1[1] > p1[0])
-        True
-        >>> _positive_class_probs(torch.zeros(3))  # doctest: +ELLIPSIS
-        Traceback (most recent call last):
-        ...
-        ValueError: Expected logits (N, C)...
-        >>> _positive_class_probs(torch.zeros(2, 3))  # doctest: +ELLIPSIS
-        Traceback (most recent call last):
-        ...
-        ValueError: ...1 or 2 output dims...
-    """
-    if logits.ndim != 2:
-        raise ValueError(f"Expected logits (N, C), got {tuple(logits.shape)}")
-    if logits.shape[1] == 2:
-        return torch.softmax(logits, dim=-1)[:, 1]
-    if logits.shape[1] == 1:
-        return torch.sigmoid(logits.squeeze(-1))
-    raise ValueError(f"Expected 1 or 2 output dims for binary AUROC, got {logits.shape[1]}")
+from .metrics import positive_class_probs
 
 
 def _resolve_val_dataloader(trainer: pl.Trainer):
@@ -436,7 +406,7 @@ class EndOfFitValAUROCCallback(Callback):
                 targets = task.extract_targets(batch)
                 if not isinstance(targets, Tensor):
                     continue
-                probs_chunks.append(_positive_class_probs(out.logits).detach().float().cpu())
+                probs_chunks.append(positive_class_probs(out.logits).detach().float().cpu())
                 target_chunks.append(targets.detach().float().cpu().view(-1))
 
         if not probs_chunks:

--- a/src/medrap/train/factory.py
+++ b/src/medrap/train/factory.py
@@ -1,0 +1,64 @@
+"""Instantiation helpers that wire structured configs into live training objects."""
+
+from typing import Any, cast
+
+import torch  # noqa: F401 — needed in doctests
+from hydra_zen import instantiate
+from meds_torchdata import MEDSTorchBatch  # noqa: F401 — needed in doctests
+
+from ..model.model import RetrievalAugmentedModel
+from .lightning_module import MedRAPSupervisedLightningModule
+
+instantiate_any = cast("Any", instantiate)
+
+
+def instantiate_training_module(config: Any) -> MedRAPSupervisedLightningModule:
+    """Instantiate the configured training wrapper around the plain RAP model.
+
+    Args:
+        config: Training config containing the plain RAP model composition under the
+            top-level pipeline fields and the supervised wrapper/task under
+            ``config.training``.
+
+    Returns:
+        MedRAPSupervisedLightningModule: Lightning wrapper whose plain model returns
+        logits shaped ``(B, config.training.task.output_dim)`` for a batch of size
+        ``B``.
+
+    Examples:
+        >>> from medrap.configs import RAPTrainConfig
+        >>> module = instantiate_training_module(RAPTrainConfig(output_dir="outputs/demo"))
+        >>> module.__class__.__name__
+        'MedRAPSupervisedLightningModule'
+        >>> module.task.output_dim
+        1
+        >>> module.loss_fn.__class__.__name__
+        'BinaryClassificationLoss'
+        >>> batch = MEDSTorchBatch(
+        ...     code=torch.LongTensor([[101, 7, 0], [42, 3, 0]]),
+        ...     numeric_value=torch.FloatTensor([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]),
+        ...     numeric_value_mask=torch.BoolTensor([[False, False, False], [False, False, False]]),
+        ...     time_delta_days=torch.FloatTensor([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]),
+        ...     boolean_value=torch.BoolTensor([True, False]),
+        ... )
+        >>> out = module.model.forward(batch)
+        >>> tuple(out.logits.shape)
+        (2, 1)
+        >>> targets = module.task.extract_targets(batch)
+        >>> module.loss_fn(out, targets).ndim
+        0
+    """
+    plain_model = RetrievalAugmentedModel(
+        encoder=instantiate_any(config.encoder),
+        query_projector=instantiate_any(config.query_projector),
+        retriever=instantiate_any(config.retriever),
+        retrieval_encoder=instantiate_any(config.retrieval_encoder),
+        fusion=instantiate_any(config.fusion),
+        pooling=instantiate_any(config.pooling),
+        head=instantiate_any(config.head),
+        marginalized_retrieval=bool(getattr(config, "marginalized_retrieval", False)),
+        marginalized_score_similarity=str(getattr(config, "marginalized_score_similarity", "dot")),
+    )
+    task = instantiate_any(config.training.task)
+    loss_fn = instantiate_any(config.training.loss)
+    return instantiate_any(config.training.module, model=plain_model, task=task, loss_fn=loss_fn)

--- a/src/medrap/train/lightning_module.py
+++ b/src/medrap/train/lightning_module.py
@@ -10,10 +10,10 @@ from torch.optim import Optimizer
 from transformers import get_cosine_schedule_with_warmup
 
 from ..types import ModelOutput
+from .losses import BinaryClassificationLoss
 from .metrics import binary_auroc_torch, multitask_auroc_torch, positive_class_probs
 from .retrieval_logging import model_diagnostic_scalars
 from .task import (
-    BinaryClassificationLoss,
     BinaryClassificationTask,
     SupervisedLoss,
     SupervisedTask,
@@ -90,7 +90,7 @@ class MedRAPSupervisedLightningModule(lightning.LightningModule):
         """
         return self.model(batch)
 
-    def _iter_no_decay_names(self) -> set[str]:
+    def _no_decay_names(self) -> set[str]:
         no_decay_names: set[str] = set()
         norm_modules = (
             nn.BatchNorm1d,
@@ -111,7 +111,7 @@ class MedRAPSupervisedLightningModule(lightning.LightningModule):
         return no_decay_names
 
     def _grouped_parameters(self) -> list[dict[str, object]]:
-        no_decay_names = self._iter_no_decay_names()
+        no_decay_names = self._no_decay_names()
         decay_params: list[nn.Parameter] = []
         no_decay_params: list[nn.Parameter] = []
 
@@ -131,6 +131,32 @@ class MedRAPSupervisedLightningModule(lightning.LightningModule):
         return groups
 
     def _run_supervised_step(self, raw_batch: MEDSTorchBatch, *, stage: str) -> Tensor:
+        """Run one supervised forward pass, compute loss, and log diagnostics.
+
+        Examples:
+            >>> from medrap.train.losses import MarginalizedRetrievalSupervisedLoss
+            >>> from medrap.train.task import MarginalizedBinaryClassificationTask
+            >>> class _MargModel(nn.Module):
+            ...     def forward(self, batch: MEDSTorchBatch) -> ModelOutput:
+            ...         return ModelOutput(
+            ...             logits=torch.zeros(2, 2),
+            ...             metadata={
+            ...                 "differentiable_doc_scores": torch.randn(2, 3),
+            ...                 "per_doc_logits": torch.randn(2, 3, 2),
+            ...             },
+            ...         )
+            >>> mm = MedRAPSupervisedLightningModule(
+            ...     model=_MargModel(),
+            ...     task=MarginalizedBinaryClassificationTask(),
+            ...     loss_fn=MarginalizedRetrievalSupervisedLoss(),
+            ... )
+            >>> log_names: list = []
+            >>> mm.log = lambda *a, **k: log_names.append(a[0])
+            >>> mm.log_dict = lambda d, *a, **k: log_names.extend(d)
+            >>> _ = mm._run_supervised_step(make_supervised_batch(), stage="train")
+            >>> any(str(n).startswith("retrieval/train/") for n in log_names)
+            True
+        """
         predictions = self.forward(raw_batch)
         targets = self.task.extract_targets(raw_batch)
         if isinstance(targets, torch.Tensor):
@@ -159,11 +185,9 @@ class MedRAPSupervisedLightningModule(lightning.LightningModule):
                 prog_bar=not is_train,
                 batch_size=batch_size,
             )
-        diagnostics_enabled = self.diagnostics_every_n_steps > 0
-        should_log_train_diagnostics = (
-            diagnostics_enabled and is_train and (self.global_step % self.diagnostics_every_n_steps == 0)
-        )
-        if diagnostics_enabled and (should_log_train_diagnostics or not is_train):
+        if self.diagnostics_every_n_steps > 0 and (
+            not is_train or self.global_step % self.diagnostics_every_n_steps == 0
+        ):
             self.log_dict(
                 model_diagnostic_scalars(predictions, raw_batch, stage=stage),
                 on_step=is_train,
@@ -349,6 +373,33 @@ class MedRAPSupervisedLightningModule(lightning.LightningModule):
             (2, 1, 1)
             >>> tuple(result["doc_key_embeddings"].shape)
             (2, 1, 1, 4)
+
+            Batch without labels: ``'targets'`` is absent from the result.
+
+            >>> unlabeled = MEDSTorchBatch(
+            ...     code=torch.LongTensor([[1, 2, 3]]),
+            ...     numeric_value=torch.zeros(1, 3),
+            ...     numeric_value_mask=torch.zeros(1, 3, dtype=torch.bool),
+            ...     time_delta_days=torch.zeros(1, 3),
+            ... )
+            >>> "targets" not in module.predict_step(unlabeled, batch_idx=0)
+            True
+
+            Marginalized-retrieval metadata is passed through to the result dict.
+
+            >>> class _MargPredModel(nn.Module):
+            ...     def forward(self, batch: MEDSTorchBatch) -> ModelOutput:
+            ...         return ModelOutput(
+            ...             logits=torch.zeros(2, 1),
+            ...             metadata={
+            ...                 "per_doc_logits": torch.zeros(2, 3, 1),
+            ...                 "differentiable_doc_scores": torch.zeros(2, 3),
+            ...             },
+            ...         )
+            >>> marg_module = MedRAPSupervisedLightningModule(model=_MargPredModel())
+            >>> marg_result = marg_module.predict_step(make_supervised_batch(), batch_idx=0)
+            >>> "per_doc_logits" in marg_result and "differentiable_doc_scores" in marg_result
+            True
         """
         predictions = self.forward(batch)
         meta = predictions.metadata
@@ -361,7 +412,7 @@ class MedRAPSupervisedLightningModule(lightning.LightningModule):
             targets = self.task.extract_targets(batch)
             if isinstance(targets, Tensor):
                 result["targets"] = targets.detach().cpu()
-        except Exception:
+        except (AttributeError, ValueError):
             pass
 
         query_out = meta.get("query_output")
@@ -382,7 +433,7 @@ class MedRAPSupervisedLightningModule(lightning.LightningModule):
 
         return result
 
-    def configure_optimizers(self) -> Optimizer:
+    def configure_optimizers(self) -> Optimizer | dict[str, object]:
         """Construct the optimizer for the wrapped plain model.
 
         Returns:
@@ -435,36 +486,21 @@ class MedRAPSupervisedLightningModule(lightning.LightningModule):
             ... }
             >>> id(task.scale) in optimized_params
             True
-            >>> from medrap.train.losses import MarginalizedRetrievalSupervisedLoss
-            >>> from medrap.train.task import MarginalizedBinaryClassificationTask
-            >>> class _MargModel(nn.Module):
-            ...     def forward(self, batch: MEDSTorchBatch) -> ModelOutput:
-            ...         return ModelOutput(
-            ...             logits=torch.zeros(2, 2),
-            ...             metadata={
-            ...                 "differentiable_doc_scores": torch.randn(2, 3),
-            ...                 "per_doc_logits": torch.randn(2, 3, 2),
-            ...             },
-            ...         )
-            >>> mm = MedRAPSupervisedLightningModule(
-            ...     model=_MargModel(),
-            ...     task=MarginalizedBinaryClassificationTask(),
-            ...     loss_fn=MarginalizedRetrievalSupervisedLoss(),
-            ... )
-            >>> log_names: list = []
-            >>> mm.log = lambda *a, **k: log_names.append(a[0])
-            >>> mm.log_dict = lambda d, *a, **k: log_names.extend(d)
-            >>> _ = mm._run_supervised_step(make_supervised_batch(), stage="train")
-            >>> any(str(n).startswith("retrieval/train/") for n in log_names)
-            True
         """
         optimizer = self.optimizer_factory(self._grouped_parameters())
         if self.warmup_steps == 0:
             return optimizer
+        num_steps = self.trainer.estimated_stepping_batches
+        if not isinstance(num_steps, int):
+            raise ValueError(
+                "configure_optimizers: cannot build cosine LR schedule because "
+                "estimated_stepping_batches is not an integer (the dataset may not implement "
+                "__len__). Use a dataset with a known length or pass max_steps to the Trainer."
+            )
         scheduler = get_cosine_schedule_with_warmup(
             optimizer,
             num_warmup_steps=self.warmup_steps,
-            num_training_steps=self.trainer.estimated_stepping_batches,
+            num_training_steps=num_steps,
         )
         return {
             "optimizer": optimizer,

--- a/src/medrap/train/lightning_module.py
+++ b/src/medrap/train/lightning_module.py
@@ -486,6 +486,15 @@ class MedRAPSupervisedLightningModule(lightning.LightningModule):
             ... }
             >>> id(task.scale) in optimized_params
             True
+            >>> from types import SimpleNamespace
+            >>> warmup_module = MedRAPSupervisedLightningModule(
+            ...     model=ModelOutputBinaryModel(), warmup_steps=10
+            ... )
+            >>> warmup_module._trainer = SimpleNamespace(estimated_stepping_batches=float("inf"))
+            >>> warmup_module.configure_optimizers()  # doctest: +ELLIPSIS
+            Traceback (most recent call last):
+                ...
+            ValueError: configure_optimizers: cannot build cosine LR schedule...
         """
         optimizer = self.optimizer_factory(self._grouped_parameters())
         if self.warmup_steps == 0:

--- a/src/medrap/train/losses.py
+++ b/src/medrap/train/losses.py
@@ -5,7 +5,7 @@ import torch.nn.functional as functional
 from torch import Tensor, nn
 
 from ..types import ModelOutput
-from .task import SupervisedLoss, TaskTargets
+from .task import SupervisedLoss, TaskTargets, _flatten_binary_logits, _flatten_binary_targets
 
 
 class MultiTaskBCELoss(SupervisedLoss):
@@ -152,6 +152,11 @@ class MultiTaskBCEMarginalizedLoss(SupervisedLoss):
             raise ValueError(
                 "MultiTaskBCEMarginalizedLoss requires marginalized_retrieval=True; "
                 "metadata missing 'per_doc_logits'."
+            )
+        if per_doc_logits.shape[2] != self.num_tasks:
+            raise ValueError(
+                f"MultiTaskBCEMarginalizedLoss(num_tasks={self.num_tasks}) expects "
+                f"per_doc_logits shaped (B, K, {self.num_tasks}), got {tuple(per_doc_logits.shape)}"
             )
         if not isinstance(doc_scores, Tensor):
             raise ValueError(
@@ -311,41 +316,41 @@ class MarginalizedRetrievalSupervisedLoss(SupervisedLoss):
 
         Missing or invalid metadata:
 
-            >>> MarginalizedRetrievalSupervisedLoss()(
-            ...     ModelOutput(logits=torch.zeros(2, 2)), {"x": torch.tensor(1.0)}
-            ... )  # doctest: +ELLIPSIS
-            Traceback (most recent call last):
-            ...
-            ValueError: ...tensor targets...
-            >>> MarginalizedRetrievalSupervisedLoss()(
-            ...     ModelOutput(logits=torch.zeros(1, 2), metadata={}), torch.tensor([0.0])
-            ... )  # doctest: +ELLIPSIS
-            Traceback (most recent call last):
-            ...
-            ValueError: ...per_doc_logits...
-            >>> MarginalizedRetrievalSupervisedLoss()(
-            ...     ModelOutput(
-            ...         logits=torch.zeros(1, 2),
-            ...         metadata={"per_doc_logits": torch.zeros(1, 2, 2)},
-            ...     ),
-            ...     torch.tensor([0.0]),
-            ... )  # doctest: +ELLIPSIS
-            Traceback (most recent call last):
-            ...
-            ValueError: ...differentiable_doc_scores...
-            >>> MarginalizedRetrievalSupervisedLoss()(
-            ...     ModelOutput(
-            ...         logits=torch.zeros(1, 2),
-            ...         metadata={
-            ...             "per_doc_logits": torch.zeros(1, 2, 2),
-            ...             "differentiable_doc_scores": torch.zeros(1, 2, 3),
-            ...         },
-            ...     ),
-            ...     torch.tensor([0.0]),
-            ... )  # doctest: +ELLIPSIS
-            Traceback (most recent call last):
-            ...
-            ValueError: ...(B, K)...
+        >>> MarginalizedRetrievalSupervisedLoss()(
+        ...     ModelOutput(logits=torch.zeros(2, 2)), {"x": torch.tensor(1.0)}
+        ... )  # doctest: +ELLIPSIS
+        Traceback (most recent call last):
+        ...
+        ValueError: ...tensor targets...
+        >>> MarginalizedRetrievalSupervisedLoss()(
+        ...     ModelOutput(logits=torch.zeros(1, 2), metadata={}), torch.tensor([0.0])
+        ... )  # doctest: +ELLIPSIS
+        Traceback (most recent call last):
+        ...
+        ValueError: ...per_doc_logits...
+        >>> MarginalizedRetrievalSupervisedLoss()(
+        ...     ModelOutput(
+        ...         logits=torch.zeros(1, 2),
+        ...         metadata={"per_doc_logits": torch.zeros(1, 2, 2)},
+        ...     ),
+        ...     torch.tensor([0.0]),
+        ... )  # doctest: +ELLIPSIS
+        Traceback (most recent call last):
+        ...
+        ValueError: ...differentiable_doc_scores...
+        >>> MarginalizedRetrievalSupervisedLoss()(
+        ...     ModelOutput(
+        ...         logits=torch.zeros(1, 2),
+        ...         metadata={
+        ...             "per_doc_logits": torch.zeros(1, 2, 2),
+        ...             "differentiable_doc_scores": torch.zeros(1, 2, 3),
+        ...         },
+        ...     ),
+        ...     torch.tensor([0.0]),
+        ... )  # doctest: +ELLIPSIS
+        Traceback (most recent call last):
+        ...
+        ValueError: ...(B, K)...
     """
 
     def __init__(self) -> None:
@@ -370,3 +375,51 @@ class MarginalizedRetrievalSupervisedLoss(SupervisedLoss):
             doc_scores=doc_scores,
             targets=targets_long,
         )
+
+
+class BinaryClassificationLoss(SupervisedLoss):
+    """Binary BCE-with-logits loss for scalar binary predictions.
+
+    Returns:
+        BinaryClassificationLoss: Loss helper that accepts ``ModelOutput``
+        predictions with logits shaped ``(B, 1)`` and binary tensor targets
+        shaped ``(B,)``.
+    """
+
+    def forward(self, predictions: ModelOutput, targets: TaskTargets) -> Tensor:
+        """Compute BCE-with-logits loss from binary predictions and targets.
+
+        Args:
+            predictions: ``ModelOutput`` predictions with logits shaped
+                ``(B, 1)``.
+            targets: Binary tensor targets shaped ``(B,)``.
+
+        Returns:
+            Tensor: Scalar loss tensor with shape ``()``.
+
+        Examples:
+            >>> import torch
+            >>> from medrap.types import ModelOutput
+            >>> loss_fn = BinaryClassificationLoss()
+            >>> predictions = ModelOutput(logits=torch.FloatTensor([[0.0], [2.0]]))
+            >>> targets = torch.BoolTensor([False, True])
+            >>> round(float(loss_fn(predictions, targets)), 4)
+            0.41
+            >>> loss_fn(
+            ...     ModelOutput(logits=torch.FloatTensor([[0.0], [2.0]])),
+            ...     {"labels": torch.FloatTensor([0.0, 1.0])},
+            ... )  # doctest: +ELLIPSIS
+            Traceback (most recent call last):
+                ...
+            ValueError: BinaryClassificationLoss expects tensor targets, not structured targets.
+            >>> loss_fn(
+            ...     ModelOutput(logits=torch.FloatTensor([[0.0], [2.0]])),
+            ...     torch.BoolTensor([[False], [True]]),
+            ... )  # doctest: +ELLIPSIS
+            Traceback (most recent call last):
+                ...
+            ValueError: BinaryClassificationLoss expects targets shaped (B,); got (2, 1)
+        """
+        flat_logits = _flatten_binary_logits(predictions, owner="BinaryClassificationLoss")
+        flat_targets = _flatten_binary_targets(targets, owner="BinaryClassificationLoss")
+        return torch.nn.functional.binary_cross_entropy_with_logits(flat_logits, flat_targets)

--- a/src/medrap/train/losses.py
+++ b/src/medrap/train/losses.py
@@ -141,6 +141,22 @@ class MultiTaskBCEMarginalizedLoss(SupervisedLoss):
 
         Returns:
             Scalar loss.
+
+        Examples:
+            >>> import torch
+            >>> from medrap.types import ModelOutput
+            >>> loss_fn = MultiTaskBCEMarginalizedLoss(num_tasks=2)
+            >>> bad_pred = ModelOutput(
+            ...     logits=torch.zeros(2, 2),
+            ...     metadata={
+            ...         "per_doc_logits": torch.zeros(2, 4, 3),
+            ...         "differentiable_doc_scores": torch.zeros(2, 4),
+            ...     },
+            ... )
+            >>> loss_fn(bad_pred, torch.zeros(2, 2))  # doctest: +ELLIPSIS
+            Traceback (most recent call last):
+                ...
+            ValueError: MultiTaskBCEMarginalizedLoss(num_tasks=2) expects per_doc_logits shaped (B, K, 2)...
         """
         if not isinstance(targets, Tensor):
             raise ValueError("MultiTaskBCEMarginalizedLoss expects tensor targets.")

--- a/src/medrap/train/task.py
+++ b/src/medrap/train/task.py
@@ -3,7 +3,7 @@
 from abc import ABC, abstractmethod
 from collections.abc import Mapping
 
-import torch
+import torch  # noqa: F401 — needed in doctests (e.g. torch.float32)
 from meds_torchdata import MEDSTorchBatch
 from torch import Tensor, nn
 
@@ -26,6 +26,19 @@ def _flatten_binary_targets(targets: TaskTargets, *, owner: str) -> Tensor:
     if tensor_targets.ndim == 1:
         return tensor_targets.float()
     raise ValueError(f"{owner} expects targets shaped (B,); got {tuple(tensor_targets.shape)}")
+
+
+def _extract_boolean_value(batch: MEDSTorchBatch, label_field: str, owner: str) -> Tensor:
+    targets = getattr(batch, label_field, None)
+    if not isinstance(targets, Tensor):
+        raise ValueError(f"Expected {label_field} targets on the MEDS batch.")
+    if targets.ndim == 2 and targets.shape[1] == 1:
+        targets = targets.squeeze(1)
+    elif targets.ndim != 1:
+        raise ValueError(
+            f"{owner} expects {label_field} shaped (B,) or (B, 1); got {tuple(targets.shape)}"
+        )
+    return targets.float()
 
 
 class SupervisedTask(nn.Module, ABC):
@@ -145,17 +158,7 @@ class BinaryClassificationTask(SupervisedTask):
                 ...
             ValueError: BinaryClassificationTask expects boolean_value shaped (B,) or (B, 1); got (2, 2)
         """
-        targets = getattr(batch, self.label_field, None)
-        if not isinstance(targets, Tensor):
-            raise ValueError(f"Expected {self.label_field} targets on the MEDS batch.")
-        if targets.ndim == 2 and targets.shape[1] == 1:
-            targets = targets.squeeze(1)
-        elif targets.ndim != 1:
-            raise ValueError(
-                f"BinaryClassificationTask expects {self.label_field} shaped (B,) or (B, 1); "
-                f"got {tuple(targets.shape)}"
-            )
-        return targets.float()
+        return _extract_boolean_value(batch, self.label_field, "BinaryClassificationTask")
 
     def metrics(self, predictions: ModelOutput, targets: TaskTargets) -> Mapping[str, Tensor]:
         """Return binary-accuracy metrics derived from logits.
@@ -188,8 +191,8 @@ class BinaryClassificationTask(SupervisedTask):
         """
         flat_logits = _flatten_binary_logits(predictions, owner="BinaryClassificationTask")
         flat_targets = _flatten_binary_targets(targets, owner="BinaryClassificationTask").bool()
-        predictions = flat_logits >= 0
-        return {"accuracy": (predictions == flat_targets).float().mean()}
+        preds = flat_logits >= 0
+        return {"accuracy": (preds == flat_targets).float().mean()}
 
 
 class MarginalizedBinaryClassificationTask(SupervisedTask):
@@ -250,17 +253,7 @@ class MarginalizedBinaryClassificationTask(SupervisedTask):
 
     def extract_targets(self, batch: MEDSTorchBatch) -> Tensor:
         """Same as :class:`BinaryClassificationTask` (float 0/1 targets)."""
-        targets = getattr(batch, self.label_field, None)
-        if not isinstance(targets, Tensor):
-            raise ValueError(f"Expected {self.label_field} targets on the MEDS batch.")
-        if targets.ndim == 2 and targets.shape[1] == 1:
-            targets = targets.squeeze(1)
-        elif targets.ndim != 1:
-            raise ValueError(
-                f"MarginalizedBinaryClassificationTask expects {self.label_field} shaped (B,) or (B, 1); "
-                f"got {tuple(targets.shape)}"
-            )
-        return targets.float()
+        return _extract_boolean_value(batch, self.label_field, "MarginalizedBinaryClassificationTask")
 
     def metrics(self, predictions: ModelOutput, targets: TaskTargets) -> Mapping[str, Tensor]:
         logits = predictions.logits
@@ -347,47 +340,3 @@ class MultiTaskBinaryClassificationTask(SupervisedTask):
         return {"accuracy": (correct * valid.float()).sum() / valid.float().sum().clamp(min=1)}
 
 
-class BinaryClassificationLoss(SupervisedLoss):
-    """Binary BCE-with-logits loss for scalar binary predictions.
-
-    Returns:
-        BinaryClassificationLoss: Loss helper that accepts ``ModelOutput``
-        predictions with logits shaped ``(B, 1)`` and binary tensor targets
-        shaped ``(B,)``.
-    """
-
-    def forward(self, predictions: ModelOutput, targets: TaskTargets) -> Tensor:
-        """Compute BCE-with-logits loss from binary predictions and targets.
-
-        Args:
-            predictions: ``ModelOutput`` predictions with logits shaped
-                ``(B, 1)``.
-            targets: Binary tensor targets shaped ``(B,)``.
-
-        Returns:
-            Tensor: Scalar loss tensor with shape ``()``.
-
-        Examples:
-            >>> loss_fn = BinaryClassificationLoss()
-            >>> predictions = ModelOutput(logits=torch.FloatTensor([[0.0], [2.0]]))
-            >>> targets = torch.BoolTensor([False, True])
-            >>> round(float(loss_fn(predictions, targets)), 4)
-            0.41
-            >>> loss_fn(
-            ...     ModelOutput(logits=torch.FloatTensor([[0.0], [2.0]])),
-            ...     {"labels": torch.FloatTensor([0.0, 1.0])},
-            ... )  # doctest: +ELLIPSIS
-            Traceback (most recent call last):
-                ...
-            ValueError: BinaryClassificationLoss expects tensor targets, not structured targets.
-            >>> loss_fn(
-            ...     ModelOutput(logits=torch.FloatTensor([[0.0], [2.0]])),
-            ...     torch.BoolTensor([[False], [True]]),
-            ... )  # doctest: +ELLIPSIS
-            Traceback (most recent call last):
-                ...
-            ValueError: BinaryClassificationLoss expects targets shaped (B,); got (2, 1)
-        """
-        flat_logits = _flatten_binary_logits(predictions, owner="BinaryClassificationLoss")
-        flat_targets = _flatten_binary_targets(targets, owner="BinaryClassificationLoss")
-        return torch.nn.functional.binary_cross_entropy_with_logits(flat_logits, flat_targets)

--- a/src/medrap/train/task.py
+++ b/src/medrap/train/task.py
@@ -35,9 +35,7 @@ def _extract_boolean_value(batch: MEDSTorchBatch, label_field: str, owner: str) 
     if targets.ndim == 2 and targets.shape[1] == 1:
         targets = targets.squeeze(1)
     elif targets.ndim != 1:
-        raise ValueError(
-            f"{owner} expects {label_field} shaped (B,) or (B, 1); got {tuple(targets.shape)}"
-        )
+        raise ValueError(f"{owner} expects {label_field} shaped (B,) or (B, 1); got {tuple(targets.shape)}")
     return targets.float()
 
 
@@ -338,5 +336,3 @@ class MultiTaskBinaryClassificationTask(SupervisedTask):
         preds = (logits >= 0).float()
         correct = (preds == targets.nan_to_num(0.0)).float()
         return {"accuracy": (correct * valid.float()).sum() / valid.float().sum().clamp(min=1)}
-
-

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -164,7 +164,8 @@ def test_prepare_train_run_overwrite_removes_stale_files(tmp_path: Path) -> None
         }
     )
     OmegaConf.save(cfg, output_dir / "config.yaml")
-    assert cli._prepare_train_run(cfg) is None
+    _, ckpt_path = cli._prepare_train_run(cfg)
+    assert ckpt_path is None
     assert not stale.exists()
 
 
@@ -247,17 +248,17 @@ def test_ensure_lightning_csv_log_dirs_creates_version_directory(tmp_path) -> No
 
 
 def test_run_eval_requires_checkpoint_path_before_loading(tmp_path) -> None:
-    cfg = OmegaConf.create(
-        {
-            "output_dir": str(tmp_path / "eval"),
-            "checkpoint_path": "",
-            "eval_mode": "validate",
-            "training": {"trainer": {"default_root_dir": "."}},
-        }
+    _assert_cli_failure(
+        lambda: _run_eval_cli(
+            [
+                f"output_dir={tmp_path / 'eval'}",
+                "checkpoint_path=",
+                "training/datamodule=synthetic",
+            ]
+        ),
+        allowed_exceptions=(SystemExit, ValueError),
+        expected_message="checkpoint_path must be set",
     )
-
-    with pytest.raises(ValueError, match="checkpoint_path must be set"):
-        cli._run_eval(cfg)
 
 
 def test_bind_trainer_paths_sets_single_logger_save_dir(tmp_path) -> None:
@@ -479,6 +480,8 @@ def test_copy_best_checkpoint_noops_without_callback_or_path(tmp_path: Path) -> 
 
 def test_run_eval_rejects_unknown_eval_mode(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
     class StubTrainer:
+        loggers: list = []  # noqa: RUF012
+
         def validate(self, module, datamodule=None) -> None:  # pragma: no cover
             raise AssertionError("validate should not run")
 
@@ -487,18 +490,20 @@ def test_run_eval_rejects_unknown_eval_mode(tmp_path, monkeypatch: pytest.Monkey
 
     monkeypatch.setattr(cli, "_load_training_module_checkpoint", lambda cfg, checkpoint_path: object())
     monkeypatch.setattr(cli, "instantiate", lambda trainer_cfg: StubTrainer())
-    monkeypatch.setattr(cli, "instantiate_datamodule", lambda cfg: object())
-    cfg = OmegaConf.create(
-        {
-            "output_dir": str(tmp_path / "eval"),
-            "checkpoint_path": str(tmp_path / "model.ckpt"),
-            "eval_mode": "predict",
-            "training": {"trainer": {"default_root_dir": "."}},
-        }
-    )
+    monkeypatch.setattr(cli, "_instantiate_datamodule", lambda cfg: object())
 
-    with pytest.raises(ValueError, match="eval_mode must be 'validate' or 'test'"):
-        cli._run_eval(cfg)
+    _assert_cli_failure(
+        lambda: _run_eval_cli(
+            [
+                f"output_dir={tmp_path / 'eval'}",
+                f"checkpoint_path={tmp_path / 'model.ckpt'}",
+                "eval_mode=predict",
+                "training/datamodule=synthetic",
+            ]
+        ),
+        allowed_exceptions=(SystemExit, ValueError),
+        expected_message="eval_mode must be 'validate' or 'test'",
+    )
 
 
 def test_preprocess_entrypoint_runs_with_hydra_overrides(monkeypatch, tmp_path) -> None:

--- a/tests/test_hydra_config_integration.py
+++ b/tests/test_hydra_config_integration.py
@@ -1,13 +1,14 @@
 import torch
 from datasets import Dataset
 from hydra import compose, initialize_config_module
+from hydra_zen import instantiate
 from meds_torchdata import MEDSTorchBatch
 from torch import nn
 
-from medrap.configs import instantiate_datamodule, instantiate_model, instantiate_training_module
 from medrap.model.model import RetrievalAugmentedModel
 from medrap.model.retrievers import HFDatasetRetriever
 from medrap.prepare_retrieval.preparation import OrderedFieldDocumentRenderer, prepare_retrieval_dataset
+from medrap.train.factory import instantiate_training_module
 from medrap.train.lightning_module import MedRAPSupervisedLightningModule
 from medrap.train.task import SupervisedTask
 
@@ -32,7 +33,7 @@ def test_train_config_composes_training_layer() -> None:
         )
 
     lightning_module = instantiate_training_module(cfg)
-    datamodule = instantiate_datamodule(cfg)
+    datamodule = instantiate(cfg.training.datamodule)
 
     assert isinstance(lightning_module, MedRAPSupervisedLightningModule)
     assert isinstance(lightning_module.model, RetrievalAugmentedModel)
@@ -57,7 +58,7 @@ def test_eval_config_composes_training_layer() -> None:
         )
 
     lightning_module = instantiate_training_module(cfg)
-    datamodule = instantiate_datamodule(cfg)
+    datamodule = instantiate(cfg.training.datamodule)
 
     assert isinstance(lightning_module, MedRAPSupervisedLightningModule)
     assert isinstance(lightning_module.model, RetrievalAugmentedModel)
@@ -85,7 +86,7 @@ def test_train_config_supports_meds_datamodule_overrides(tmp_path) -> None:
             ],
         )
 
-    datamodule = instantiate_datamodule(cfg)
+    datamodule = instantiate(cfg.training.datamodule)
 
     assert datamodule.__class__.__name__ == "Datamodule"
 
@@ -180,7 +181,7 @@ def test_eval_config_supports_saved_hf_dataset_retriever(tmp_path) -> None:
             ],
         )
 
-    model = instantiate_model(cfg)
+    model = instantiate_training_module(cfg).model
 
     assert isinstance(model, RetrievalAugmentedModel)
     assert isinstance(model.retriever, HFDatasetRetriever)

--- a/tests/test_lightning_module.py
+++ b/tests/test_lightning_module.py
@@ -349,8 +349,6 @@ def test_lightning_module_test_step_runs(
     assert "test/loss" in metrics[0]
 
 
-
-
 def test_configure_optimizers_with_warmup_returns_scheduler_dict(
     supervised_batch: MEDSTorchBatch,
     model_output_binary_model: nn.Module,

--- a/tests/test_lightning_module.py
+++ b/tests/test_lightning_module.py
@@ -349,43 +349,6 @@ def test_lightning_module_test_step_runs(
     assert "test/loss" in metrics[0]
 
 
-def test_predict_step_returns_targets_when_available(
-    supervised_batch: MEDSTorchBatch,
-    model_output_binary_model: nn.Module,
-) -> None:
-    module = MedRAPSupervisedLightningModule(
-        model=model_output_binary_model,
-        task=BinaryClassificationTask(),
-    )
-
-    result = module.predict_step(supervised_batch, batch_idx=0)
-
-    assert "logits" in result
-    assert "targets" in result
-    assert result["logits"].device.type == "cpu"
-    assert result["targets"].device.type == "cpu"
-
-
-def test_predict_step_skips_targets_when_extract_raises(
-    model_output_binary_model: nn.Module,
-) -> None:
-    """Covers the ``except Exception: pass`` branch in ``predict_step``."""
-    # A batch without boolean_value makes BinaryClassificationTask.extract_targets raise.
-    batch_without_labels = MEDSTorchBatch(
-        code=torch.LongTensor([[1, 2, 3], [3, 2, 1]]),
-        numeric_value=torch.zeros((2, 3), dtype=torch.float32),
-        numeric_value_mask=torch.zeros((2, 3), dtype=torch.bool),
-        time_delta_days=torch.zeros((2, 3), dtype=torch.float32),
-    )
-    module = MedRAPSupervisedLightningModule(
-        model=model_output_binary_model,
-        task=BinaryClassificationTask(),
-    )
-
-    result = module.predict_step(batch_without_labels, batch_idx=0)
-
-    assert "logits" in result
-    assert "targets" not in result
 
 
 def test_configure_optimizers_with_warmup_returns_scheduler_dict(
@@ -462,43 +425,6 @@ def test_grouped_parameters_excludes_vector_parameters_from_weight_decay() -> No
     assert model.attn.in_proj_bias in no_decay_params
     assert model.linear.weight in decay_params
     assert model.linear.bias in no_decay_params
-
-
-def test_predict_step_captures_marginalized_tensors_from_metadata(
-    supervised_batch: MEDSTorchBatch,
-) -> None:
-    """Covers the ``per_doc_logits`` / ``differentiable_doc_scores`` branch."""
-
-    class MarginalizedModel(nn.Module):
-        def __init__(self) -> None:
-            super().__init__()
-            self.layer_norm = nn.LayerNorm(3)
-            self.linear = nn.Linear(3, 1)
-
-        def forward(self, batch: MEDSTorchBatch) -> ModelOutput:
-            features = self.layer_norm(batch.code.float())
-            logits = self.linear(features)
-            # Shape chosen arbitrarily; predict_step only checks isinstance(value, Tensor).
-            return ModelOutput(
-                logits=logits,
-                metadata={
-                    "per_doc_logits": logits.unsqueeze(-1),
-                    "differentiable_doc_scores": logits.squeeze(-1),
-                    "per_doc_logits_non_tensor": "skip-me",
-                },
-            )
-
-    module = MedRAPSupervisedLightningModule(
-        model=MarginalizedModel(),
-        task=BinaryClassificationTask(),
-    )
-
-    result = module.predict_step(supervised_batch, batch_idx=0)
-
-    assert "per_doc_logits" in result
-    assert "differentiable_doc_scores" in result
-    assert result["per_doc_logits"].device.type == "cpu"
-    assert result["differentiable_doc_scores"].device.type == "cpu"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **`cli.py`**: Inlined `_run_train`/`_run_eval` into their main functions, consolidated duplicate output-dir setup into a single `_prepare_train_run` return value, added private `_instantiate_datamodule` for test monkeypatching
- **`train/factory.py`** (new): Moved `instantiate_training_module` (and the removed `instantiate_model`/`instantiate_datamodule`) here from `configs.py`, following the `prepare_retrieval/preparation.py` pattern
- **`configs.py`**: Removed all instantiation functions; updated `BinaryClassificationLoss` import to its new home in `losses.py`
- **`train/task.py`**: Extracted `_extract_boolean_value` helper to eliminate the duplicated `extract_targets` body in `BinaryClassificationTask` and `MarginalizedBinaryClassificationTask`; fixed a local variable shadowing the `predictions` parameter in `metrics`
- **`train/losses.py`**: Moved `BinaryClassificationLoss` here from `task.py`; activated the stored `num_tasks` as a shape assertion in `MultiTaskBCEMarginalizedLoss`; fixed misindented doctest prompts in `MarginalizedRetrievalSupervisedLoss`
- **`train/callbacks.py`**: Removed duplicate `_positive_class_probs`; imports it from `metrics` instead
- **`train/lightning_module.py`**: Narrowed bare `except Exception` → `except (AttributeError, ValueError)` in `predict_step`; guarded against `estimated_stepping_batches = float("inf")` before building cosine LR schedule; fixed `configure_optimizers` return type annotation; renamed `_iter_no_decay_names` → `_no_decay_names`; simplified redundant diagnostics condition; redistributed overloaded doctest examples to the methods they actually test
- **`__init__.py`**: Added `MarginalizedRetrievalLoss` and `MarginalizedRetrievalSupervisedLoss` to public exports for consistency
- **`conf/training/loss/binary_bce.yaml`**: Updated `_target_` to `medrap.train.losses.BinaryClassificationLoss`
- **Tests**: Updated import paths, removed 3 pytest tests now covered by doctests

## Test plan

- [x] `uv run pytest --doctest-modules src/medrap/ tests/ -q` → 205 passed
- [x] `uv run ruff check src/medrap/ tests/` → clean

Closes #59, #60, #62 (partially)

🤖 Generated with [Claude Code](https://claude.com/claude-code)