### PR TITLE
chore(retrieval_logging): remove unreachable dead branch

### DIFF
--- a/src/medrap/train/retrieval_logging.py
+++ b/src/medrap/train/retrieval_logging.py
@@ -148,8 +148,6 @@ def _retrieval_id_scalars(retrieval: RetrieverOutput, *, prefix: str) -> dict[st
     if retrieval.doc_ids is None or retrieval.doc_ids.numel() == 0:
         return out
     top1 = retrieval.doc_ids[..., 0].detach().long().flatten()
-    if top1.numel() == 0:  # pragma: no cover - unreachable: the earlier numel()==0 guard already returns
-        return out
     unique_top1, counts = torch.unique(top1, return_counts=True)
     out[f"{prefix}/top1_unique_ratio"] = torch.tensor(
         float(unique_top1.numel()) / float(top1.numel()),


### PR DESCRIPTION
## Summary

Remove the `top1.numel() == 0` guard in `_retrieval_id_scalars` (line 151). The preceding `retrieval.doc_ids.numel() == 0` check on line 148 already returns early, making the `top1` guard unreachable. Removes the associated `# pragma: no cover` annotation.

## Test plan

- [ ] `uv run pytest --doctest-modules src/medrap/train/retrieval_logging.py` — 2 passed
- [ ] `uv run pre-commit run --files src/medrap/train/retrieval_logging.py` — all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)