### PR TITLE
fix(preprocess): filter sampled task codes by in-window positive rate

### DIFF
--- a/src/medrap/cli.py
+++ b/src/medrap/cli.py
@@ -382,6 +382,8 @@ def preprocess_main(cfg: DictConfig) -> None:
         horizon_days=cfg.horizon_days,
         min_history_days=cfg.min_history_days,
         seed=cfg.seed,
+        min_positive_count=cfg.min_positive_count,
+        candidate_pool_multiplier=cfg.candidate_pool_multiplier,
     )
     print(f"Task labels saved to {tasks_out}")
 

--- a/src/medrap/conf/_preprocess.yaml
+++ b/src/medrap/conf/_preprocess.yaml
@@ -7,6 +7,8 @@ num_tasks: 25
 horizon_days: 7.0
 min_history_days: 1.0
 seed: 42
+min_positive_count: 10 # min in-window positive occurrences for a sampled task code to be kept
+candidate_pool_multiplier: 20 # candidate codes windowed-tested per requested task
 do_overwrite: false
 
 hydra:

--- a/src/medrap/preprocess/README.md
+++ b/src/medrap/preprocess/README.md
@@ -23,6 +23,8 @@ Key options (all have defaults):
 | `horizon_days`           | 7.0     | How far ahead to look for a code occurrence           |
 | `min_history_days`       | 1.0     | Minimum history required before a prediction time     |
 | `seed`                   | 42      | Random seed for task sampling and prediction times    |
+| `min_positive_count`     | 10      | Minimum in-window positive occurrences (train split) a candidate code needs to be selected as a task |
+| `candidate_pool_multiplier` | 20   | Candidate codes windowed-tested per requested task before filtering by `min_positive_count` |
 
 ### Skipping stage 1 (use existing tensorized data)
 
@@ -79,6 +81,20 @@ for each subject in every split:
     whose timeline is too short for this window are excluded.
 - For each task code, the label is `1.0` if the code appears within
     `horizon_days` after the prediction time, otherwise `0.0`.
+
+Candidate codes are windowed-tested (`candidate_pool_multiplier * num_tasks`
+of them, sampled uniformly) and only kept if they have at least
+`min_positive_count` in-window positive occurrences on the train split. This
+matters because `min_subjects_per_code` (stage 1) only guarantees a code
+occurred *somewhere* in a subject's lifetime record — it says nothing about
+whether the code falls inside any single subject's much narrower
+`horizon_days`-wide prediction window. Without this filter, uniformly-sampled
+codes are frequently rare enough, relative to the windowed definition, to
+produce an all-negative task with no learning signal and an undefined
+validation AUROC. If fewer than `num_tasks` candidates pass the filter,
+`generate_tasks` raises a `ValueError` rather than silently returning
+degenerate tasks — raise `candidate_pool_multiplier`, lower
+`min_positive_count`, or lower `num_tasks` in response.
 
 Output goes to `output_dir/tasks/` and contains one parquet per split plus
 `code_index.json` (mapping task index → code string) and `metadata.json`.

--- a/src/medrap/preprocess/README.md
+++ b/src/medrap/preprocess/README.md
@@ -15,16 +15,16 @@ medrap-preprocess \
 
 Key options (all have defaults):
 
-| Option                   | Default | Description                                           |
-| ------------------------ | ------- | ----------------------------------------------------- |
-| `min_subjects_per_code`  | 100     | Drop codes appearing in fewer than this many subjects |
-| `min_events_per_subject` | 10      | Drop subjects with fewer distinct events than this    |
-| `num_tasks`              | 25      | Number of prediction tasks to generate                |
-| `horizon_days`           | 7.0     | How far ahead to look for a code occurrence           |
-| `min_history_days`       | 1.0     | Minimum history required before a prediction time     |
-| `seed`                   | 42      | Random seed for task sampling and prediction times    |
-| `min_positive_count`     | 10      | Minimum in-window positive occurrences (train split) a candidate code needs to be selected as a task |
-| `candidate_pool_multiplier` | 20   | Candidate codes windowed-tested per requested task before filtering by `min_positive_count` |
+| Option                      | Default | Description                                                                                          |
+| --------------------------- | ------- | ---------------------------------------------------------------------------------------------------- |
+| `min_subjects_per_code`     | 100     | Drop codes appearing in fewer than this many subjects                                                |
+| `min_events_per_subject`    | 10      | Drop subjects with fewer distinct events than this                                                   |
+| `num_tasks`                 | 25      | Number of prediction tasks to generate                                                               |
+| `horizon_days`              | 7.0     | How far ahead to look for a code occurrence                                                          |
+| `min_history_days`          | 1.0     | Minimum history required before a prediction time                                                    |
+| `seed`                      | 42      | Random seed for task sampling and prediction times                                                   |
+| `min_positive_count`        | 10      | Minimum in-window positive occurrences (train split) a candidate code needs to be selected as a task |
+| `candidate_pool_multiplier` | 20      | Candidate codes windowed-tested per requested task before filtering by `min_positive_count`          |
 
 ### Skipping stage 1 (use existing tensorized data)
 

--- a/src/medrap/preprocess/task_generation.py
+++ b/src/medrap/preprocess/task_generation.py
@@ -5,9 +5,16 @@ Prediction time is sampled uniformly at random from the per-subject window
 Subjects whose timeline is shorter than ``min_history_days + horizon_days`` are excluded.
 
 Task codes are sampled randomly from codes present in the train split, excluding
-synthetic time tokens (``TIMELINE//`` prefix) added by the MEDS-transforms pipeline.
-Rare-code and sparse-subject filtering is handled upstream by the MEDS-transforms
-pipeline stage, so no frequency filtering is applied here.
+synthetic time tokens (``TIMELINE//`` prefix) added by the MEDS-transforms pipeline,
+then filtered to codes with at least ``min_positive_count`` *in-window* positive
+occurrences (see :func:`_sample_task_codes`). The upstream MEDS-transforms
+``min_subjects_per_code`` filter only guarantees a code occurred somewhere in a
+subject's lifetime record; it says nothing about how often the code falls inside
+one subject's randomly-sampled ``horizon_days``-wide prediction window, which is
+what the task label actually measures. Without the in-window filter, uniformly
+sampled codes are frequently rare enough to have zero in-window positives across
+the whole cohort, producing an all-negative task with no learning signal and an
+undefined validation AUROC.
 """
 
 import json
@@ -17,25 +24,72 @@ import numpy as np
 import polars as pl
 
 
-def _sample_task_codes(meds_data_dir: str | Path, num_tasks: int, seed: int) -> list[str]:
-    """Sample ``num_tasks`` codes at random from the train split.
+def _sample_task_codes(
+    meds_data_dir: str | Path,
+    num_tasks: int,
+    seed: int,
+    *,
+    horizon_days: float = 7.0,
+    min_history_days: float = 1.0,
+    min_positive_count: int = 10,
+    candidate_pool_multiplier: int = 20,
+) -> list[str]:
+    """Sample ``num_tasks`` codes with enough in-window positive occurrences to be learnable.
 
-    Excludes synthetic ``TIMELINE//`` tokens added by the MEDS-transforms pipeline.
+    Candidate codes are drawn uniformly at random from codes present in the train
+    split (excluding synthetic ``TIMELINE//`` tokens), then filtered to codes with
+    at least ``min_positive_count`` *in-window* occurrences on the train split
+    (the same windowed-occurrence definition :func:`generate_labels` uses to build
+    labels). This guards against codes that are frequent enough to survive the
+    upstream MEDS-transforms ``min_subjects_per_code`` lifetime filter but almost
+    never fall inside any single subject's randomly-sampled prediction window,
+    which would otherwise produce an all-negative task with no learning signal.
 
     Args:
         meds_data_dir: Root of a MEDS dataset (``data/train/*.parquet``).
         num_tasks: Number of codes to sample.
         seed: Random seed.
+        horizon_days: Days after prediction time to look for code occurrence
+            (must match the value passed to label generation).
+        min_history_days: Minimum days of history before the prediction anchor
+            (must match the value passed to label generation).
+        min_positive_count: Minimum number of in-window positive occurrences (on
+            the train split) a code must have to be eligible as a task.
+        candidate_pool_multiplier: Number of candidate codes to windowed-test per
+            requested task, before filtering. Larger values cost one (bounded)
+            extra pass over the train split but are more likely to find enough
+            codes with sufficient positive occurrences.
 
     Returns:
-        List of sampled code strings (length ``<= num_tasks``).
+        List of ``num_tasks`` code strings, each with >= ``min_positive_count``
+        in-window occurrences on the train split.
 
     Raises:
-        ValueError: If no eligible codes are found.
+        ValueError: If no eligible codes are found, or fewer than ``num_tasks``
+            candidates meet the minimum positive-count threshold.
 
     Examples:
         >>> import tempfile
-        >>> from datetime import datetime
+        >>> from datetime import datetime, timedelta
+        >>> with tempfile.TemporaryDirectory() as tmpdir:
+        ...     shard_dir = Path(tmpdir) / "data" / "train"
+        ...     shard_dir.mkdir(parents=True)
+        ...     rows = {"subject_id": [], "code": [], "time": []}
+        ...     for subject_id in range(20):
+        ...         start = datetime(2020, 1, 1) + timedelta(days=subject_id)
+        ...         rows["subject_id"] += [subject_id, subject_id, subject_id]
+        ...         # RARE sits at t=0 (always before the prediction window, so it never
+        ...         # counts as an in-window positive); COMMON at t=5 days always falls
+        ...         # inside the window given the default horizon_days=7, min_history_days=1;
+        ...         # the TIMELINE marker at t=10 days opens a wide enough window to begin with.
+        ...         rows["code"] += ["DIAG//RARE", "DIAG//COMMON", "TIMELINE//DELTA//years"]
+        ...         rows["time"] += [start, start + timedelta(days=5), start + timedelta(days=10)]
+        ...     pl.DataFrame(rows).write_parquet(shard_dir / "0.parquet")
+        ...     codes = _sample_task_codes(
+        ...         tmpdir, num_tasks=1, seed=0, min_positive_count=10, candidate_pool_multiplier=20
+        ...     )
+        ...     codes == ["DIAG//COMMON"]
+        True
         >>> with tempfile.TemporaryDirectory() as tmpdir:
         ...     shard_dir = Path(tmpdir) / "data" / "train"
         ...     shard_dir.mkdir(parents=True)
@@ -46,9 +100,12 @@ def _sample_task_codes(meds_data_dir: str | Path, num_tasks: int, seed: int) -> 
         ...             "time": [datetime(2020, 1, 1), datetime(2020, 1, 2), datetime(2020, 1, 1)],
         ...         }
         ...     ).write_parquet(shard_dir / "0.parquet")
-        ...     codes = _sample_task_codes(tmpdir, num_tasks=5, seed=0)
-        ...     codes == ["DIAG//A"]
-        True
+        ...     _sample_task_codes(
+        ...         tmpdir, num_tasks=1, seed=0, min_positive_count=10
+        ...     )  # doctest: +ELLIPSIS
+        Traceback (most recent call last):
+            ...
+        ValueError: Only 0/1 candidate codes had >= 10 in-window positive occurrences...
         >>> with tempfile.TemporaryDirectory() as tmpdir:
         ...     shard_dir = Path(tmpdir) / "data" / "train"
         ...     shard_dir.mkdir(parents=True)
@@ -75,6 +132,27 @@ def _sample_task_codes(meds_data_dir: str | Path, num_tasks: int, seed: int) -> 
     )
     if not eligible:
         raise ValueError(f"No eligible task codes found in {meds_data_dir}/data/train/.")
+
+    rng = np.random.default_rng(seed)
+    pool_size = min(len(eligible), max(num_tasks * candidate_pool_multiplier, num_tasks))
+    candidates = rng.choice(eligible, size=pool_size, replace=False).tolist()
+
+    windowed = generate_labels(meds_data_dir, "train", candidates, horizon_days, min_history_days, seed)
+    if windowed.is_empty():
+        positive_counts = dict.fromkeys(candidates, 0)
+    else:
+        positive_counts = {code: int(windowed[f"task_{i}"].sum()) for i, code in enumerate(candidates)}
+
+    passing = [code for code in candidates if positive_counts[code] >= min_positive_count]
+    if len(passing) < num_tasks:
+        raise ValueError(
+            f"Only {len(passing)}/{num_tasks} candidate codes had >= {min_positive_count} "
+            f"in-window positive occurrences (horizon_days={horizon_days}, "
+            f"min_history_days={min_history_days}) among {len(candidates)} candidates sampled "
+            f"from {len(eligible)} eligible codes. Increase candidate_pool_multiplier, lower "
+            "min_positive_count, or lower num_tasks."
+        )
+    return passing[:num_tasks]
     rng = np.random.default_rng(seed)
     chosen = rng.choice(eligible, size=min(num_tasks, len(eligible)), replace=False)
     return chosen.tolist()
@@ -239,13 +317,16 @@ def generate_tasks(
     horizon_days: float = 7.0,
     min_history_days: float = 1.0,
     seed: int = 42,
+    min_positive_count: int = 10,
+    candidate_pool_multiplier: int = 20,
     splits: tuple[str, ...] = ("train", "tuning", "held_out"),
 ) -> Path:
     """Create multi-task binary labels from a MEDS cohort.
 
     Task codes are sampled randomly from codes present in the train split
-    (excluding synthetic ``TIMELINE//`` tokens). Rare-code filtering is handled
-    upstream by the MEDS-transforms pipeline.
+    (excluding synthetic ``TIMELINE//`` tokens), then filtered to codes with
+    enough in-window positive occurrences to be learnable; see
+    :func:`_sample_task_codes`.
 
     Args:
         meds_data_dir: Root of a MEDS dataset (``data/{split}/*.parquet``).
@@ -254,6 +335,10 @@ def generate_tasks(
         horizon_days: Days after prediction time to look for code occurrence.
         min_history_days: Minimum days of history before the prediction anchor.
         seed: Random seed for task selection and anchor sampling.
+        min_positive_count: Minimum in-window positive occurrences (on the train
+            split) a candidate code must have to be selected as a task.
+        candidate_pool_multiplier: Number of candidate codes to windowed-test per
+            requested task before filtering by ``min_positive_count``.
         splits: Splits to generate labels for.
 
     Returns:
@@ -261,37 +346,40 @@ def generate_tasks(
 
     Examples:
         >>> import tempfile
-        >>> from datetime import datetime
+        >>> from datetime import datetime, timedelta
         >>> with tempfile.TemporaryDirectory() as tmpdir:
         ...     for split in ("train", "tuning"):
         ...         shard_dir = Path(tmpdir) / "data" / split
         ...         shard_dir.mkdir(parents=True)
-        ...         pl.DataFrame(
-        ...             {
-        ...                 "subject_id": [1, 1, 1, 2, 2, 2],
-        ...                 "code": ["X", "Y", "X", "X", "Z", "Y"],
-        ...                 "time": [
-        ...                     datetime(2020, 1, 1),
-        ...                     datetime(2020, 1, 10),
-        ...                     datetime(2020, 1, 20),
-        ...                     datetime(2020, 2, 1),
-        ...                     datetime(2020, 2, 10),
-        ...                     datetime(2020, 2, 20),
-        ...                 ],
-        ...             }
-        ...         ).write_parquet(shard_dir / "0.parquet")
+        ...         rows = {"subject_id": [], "code": [], "time": []}
+        ...         for subject_id in range(20):
+        ...             start = datetime(2020, 1, 1) + timedelta(days=subject_id)
+        ...             rows["subject_id"] += [subject_id, subject_id, subject_id]
+        ...             rows["code"] += ["DIAG//RARE", "DIAG//COMMON", "TIMELINE//DELTA//years"]
+        ...             rows["time"] += [start, start + timedelta(days=5), start + timedelta(days=10)]
+        ...         pl.DataFrame(rows).write_parquet(shard_dir / "0.parquet")
         ...     out_dir = Path(tmpdir) / "tasks"
-        ...     returned = generate_tasks(tmpdir, out_dir, num_tasks=3, seed=0, splits=("train", "tuning"))
-        ...     returned == out_dir and (out_dir / "train.parquet").exists() and (
-        ...         out_dir / "code_index.json"
-        ...     ).exists()
+        ...     returned = generate_tasks(
+        ...         tmpdir, out_dir, num_tasks=1, seed=0, min_positive_count=10, splits=("train", "tuning")
+        ...     )
+        ...     codes = json.loads((out_dir / "code_index.json").read_text())
+        ...     is_ok = returned == out_dir and (out_dir / "train.parquet").exists()
+        ...     is_ok and codes == {"0": "DIAG//COMMON"}
         True
     """
     meds_data_dir = Path(meds_data_dir)
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    codes = _sample_task_codes(meds_data_dir, num_tasks=num_tasks, seed=seed)
+    codes = _sample_task_codes(
+        meds_data_dir,
+        num_tasks=num_tasks,
+        seed=seed,
+        horizon_days=horizon_days,
+        min_history_days=min_history_days,
+        min_positive_count=min_positive_count,
+        candidate_pool_multiplier=candidate_pool_multiplier,
+    )
 
     for split in splits:
         df = generate_labels(meds_data_dir, split, codes, horizon_days, min_history_days, seed)

--- a/src/medrap/preprocess/task_generation.py
+++ b/src/medrap/preprocess/task_generation.py
@@ -100,9 +100,7 @@ def _sample_task_codes(
         ...             "time": [datetime(2020, 1, 1), datetime(2020, 1, 2), datetime(2020, 1, 1)],
         ...         }
         ...     ).write_parquet(shard_dir / "0.parquet")
-        ...     _sample_task_codes(
-        ...         tmpdir, num_tasks=1, seed=0, min_positive_count=10
-        ...     )  # doctest: +ELLIPSIS
+        ...     _sample_task_codes(tmpdir, num_tasks=1, seed=0, min_positive_count=10)  # doctest: +ELLIPSIS
         Traceback (most recent call last):
             ...
         ValueError: Only 0/1 candidate codes had >= 10 in-window positive occurrences...

--- a/src/medrap/train/lightning_module.py
+++ b/src/medrap/train/lightning_module.py
@@ -231,22 +231,33 @@ class MedRAPSupervisedLightningModule(lightning.LightningModule):
     def _validation_auroc_metrics(self, targets: Tensor, logits: Tensor) -> dict[str, float]:
         """Compute validation-loop AUROC metrics from accumulated tensors.
 
+        Always logs ``val/auroc/n_tasks`` and ``val/auroc/n_valid_tasks`` when AUROC
+        is computable at all, so a fully-degenerate validation split (e.g. sampled
+        task codes with no in-window positive occurrences, leaving every task with a
+        single observed class) is visible as ``n_valid_tasks=0`` in the logs instead
+        of the metric silently never appearing.
+
         Examples:
             >>> module = MedRAPSupervisedLightningModule(model=ModelOutputBinaryModel())
             >>> module._validation_auroc_metrics(torch.ones(2, 1), torch.zeros(2, 1))
-            {}
+            {'val/auroc/n_tasks': 1.0, 'val/auroc/n_valid_tasks': 0.0}
             >>> module._validation_auroc_metrics(torch.FloatTensor([0, 1]), torch.zeros(2, 3))
             {}
             >>> module._validation_auroc_metrics(torch.FloatTensor([1, 1]), torch.zeros(2, 1))
-            {}
+            {'val/auroc/n_tasks': 1.0, 'val/auroc/n_valid_tasks': 0.0}
         """
         if targets.ndim == 2 and logits.ndim == 2 and targets.shape == logits.shape:
             per_task = multitask_auroc_torch(targets, logits)
-            if not per_task:
-                return {}
-            metrics = {"val/auroc/mean": sum(per_task.values()) / len(per_task)}
-            if self.validation_auroc_log_per_task:
-                metrics.update({f"val/auroc/task_{task_idx}": value for task_idx, value in per_task.items()})
+            metrics: dict[str, float] = {
+                "val/auroc/n_tasks": float(targets.shape[1]),
+                "val/auroc/n_valid_tasks": float(len(per_task)),
+            }
+            if per_task:
+                metrics["val/auroc/mean"] = sum(per_task.values()) / len(per_task)
+                if self.validation_auroc_log_per_task:
+                    metrics.update(
+                        {f"val/auroc/task_{task_idx}": value for task_idx, value in per_task.items()}
+                    )
             return metrics
 
         try:
@@ -255,7 +266,7 @@ class MedRAPSupervisedLightningModule(lightning.LightningModule):
             return {}
         score = binary_auroc_torch(targets, probs)
         if score is None or not torch.isfinite(score):
-            return {}
+            return {"val/auroc/n_tasks": 1.0, "val/auroc/n_valid_tasks": 0.0}
         return {"val/auroc": float(score.detach().cpu().item())}
 
     def training_step(self, batch: MEDSTorchBatch, _batch_idx: int) -> Tensor:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -509,7 +509,17 @@ def test_run_eval_rejects_unknown_eval_mode(tmp_path, monkeypatch: pytest.Monkey
 def test_preprocess_entrypoint_runs_with_hydra_overrides(monkeypatch, tmp_path) -> None:
     captured = {}
 
-    def _fake_generate_tasks(meds_data_dir, output_dir, *, num_tasks, horizon_days, min_history_days, seed):
+    def _fake_generate_tasks(
+        meds_data_dir,
+        output_dir,
+        *,
+        num_tasks,
+        horizon_days,
+        min_history_days,
+        seed,
+        min_positive_count,
+        candidate_pool_multiplier,
+    ):
         captured["meds_data_dir"] = str(meds_data_dir)
         captured["num_tasks"] = num_tasks
         Path(output_dir).mkdir(parents=True, exist_ok=True)
@@ -549,7 +559,17 @@ def test_preprocess_entrypoint_runs_without_tensorized_dir(monkeypatch, tmp_path
         captured["meds_data_dir"] = str(meds_data_dir)
         return inter, tens
 
-    def _fake_generate_tasks(meds_data_dir, output_dir, *, num_tasks, horizon_days, min_history_days, seed):
+    def _fake_generate_tasks(
+        meds_data_dir,
+        output_dir,
+        *,
+        num_tasks,
+        horizon_days,
+        min_history_days,
+        seed,
+        min_positive_count,
+        candidate_pool_multiplier,
+    ):
         Path(output_dir).mkdir(parents=True, exist_ok=True)
         return Path(output_dir)
 


### PR DESCRIPTION
## Summary

- `_sample_task_codes` previously sampled task codes uniformly from anything passing the upstream `min_subjects_per_code` lifetime-frequency filter, with no check on how often the code actually falls inside a subject's much narrower `horizon_days`-wide prediction window.
- On the full MIMIC-IV cohort this produced task codes with **zero in-window positives across the entire tuning split** — verified against a real `mimic_iv_sweep` run (N=25, seed=42): all 25 sampled codes had `0/36463` positives on the tuning split, making every task a degenerate always-negative classifier (`val/loss=0`, `val/accuracy=1`, `val/auroc/mean` never logged because it silently disappears when every task is undefined).
- `_sample_task_codes` now windowed-tests a candidate pool (`candidate_pool_multiplier * num_tasks` codes, default 20x) and only keeps codes with at least `min_positive_count` (default 10) in-window positive occurrences on the train split. If too few candidates pass, it raises a clear `ValueError` instead of silently returning degenerate tasks.
- Also made degenerate validation splits diagnosable instead of silent: `val/auroc/n_tasks` and `val/auroc/n_valid_tasks` are now always logged when AUROC is computable at all, so an `n_valid_tasks=0` epoch shows up in W&B instead of the metric just never appearing with no explanation.

New config knobs (both Hydra-overridable, defaults chosen conservatively): `min_positive_count=10`, `candidate_pool_multiplier=20`.

## Test plan

- [x] `pytest` — 185 passed (existing suite + updated doctests/fixtures)
- [x] `ruff check .` — clean
- [x] Doctests added/updated in `task_generation.py` and `lightning_module.py` covering both the passing and degenerate/`ValueError` paths
- [ ] Re-run `mimic_iv_sweep`'s `generate_labels.sh` on the cluster against the full MIMIC-IV cohort and confirm the sampled codes now have real positive rates and `val/auroc/mean` appears in W&B

🤖 Generated with [Claude Code](https://claude.com/claude-code)