### PR TITLE
fix(preprocess): test every eligible code, not a random subsample, for task sampling

### DIFF
--- a/src/medrap/cli.py
+++ b/src/medrap/cli.py
@@ -383,7 +383,6 @@ def preprocess_main(cfg: DictConfig) -> None:
         min_history_days=cfg.min_history_days,
         seed=cfg.seed,
         min_positive_count=cfg.min_positive_count,
-        candidate_pool_multiplier=cfg.candidate_pool_multiplier,
     )
     print(f"Task labels saved to {tasks_out}")
 

--- a/src/medrap/conf/_preprocess.yaml
+++ b/src/medrap/conf/_preprocess.yaml
@@ -8,7 +8,6 @@ horizon_days: 7.0
 min_history_days: 1.0
 seed: 42
 min_positive_count: 10 # min in-window positive occurrences for a sampled task code to be kept
-candidate_pool_multiplier: 20 # candidate codes windowed-tested per requested task
 do_overwrite: false
 
 hydra:

--- a/src/medrap/preprocess/README.md
+++ b/src/medrap/preprocess/README.md
@@ -15,16 +15,15 @@ medrap-preprocess \
 
 Key options (all have defaults):
 
-| Option                      | Default | Description                                                                                          |
-| --------------------------- | ------- | ---------------------------------------------------------------------------------------------------- |
-| `min_subjects_per_code`     | 100     | Drop codes appearing in fewer than this many subjects                                                |
-| `min_events_per_subject`    | 10      | Drop subjects with fewer distinct events than this                                                   |
-| `num_tasks`                 | 25      | Number of prediction tasks to generate                                                               |
-| `horizon_days`              | 7.0     | How far ahead to look for a code occurrence                                                          |
-| `min_history_days`          | 1.0     | Minimum history required before a prediction time                                                    |
-| `seed`                      | 42      | Random seed for task sampling and prediction times                                                   |
-| `min_positive_count`        | 10      | Minimum in-window positive occurrences (train split) a candidate code needs to be selected as a task |
-| `candidate_pool_multiplier` | 20      | Candidate codes windowed-tested per requested task before filtering by `min_positive_count`          |
+| Option                   | Default | Description                                                                                          |
+| ------------------------ | ------- | ---------------------------------------------------------------------------------------------------- |
+| `min_subjects_per_code`  | 100     | Drop codes appearing in fewer than this many subjects                                                |
+| `min_events_per_subject` | 10      | Drop subjects with fewer distinct events than this                                                   |
+| `num_tasks`              | 25      | Number of prediction tasks to generate                                                               |
+| `horizon_days`           | 7.0     | How far ahead to look for a code occurrence                                                          |
+| `min_history_days`       | 1.0     | Minimum history required before a prediction time                                                    |
+| `seed`                   | 42      | Random seed for task sampling and prediction times                                                   |
+| `min_positive_count`     | 10      | Minimum in-window positive occurrences (train split) a candidate code needs to be selected as a task |
 
 ### Skipping stage 1 (use existing tensorized data)
 
@@ -82,19 +81,20 @@ for each subject in every split:
 - For each task code, the label is `1.0` if the code appears within
     `horizon_days` after the prediction time, otherwise `0.0`.
 
-Candidate codes are windowed-tested (`candidate_pool_multiplier * num_tasks`
-of them, sampled uniformly) and only kept if they have at least
-`min_positive_count` in-window positive occurrences on the train split. This
-matters because `min_subjects_per_code` (stage 1) only guarantees a code
-occurred *somewhere* in a subject's lifetime record — it says nothing about
-whether the code falls inside any single subject's much narrower
-`horizon_days`-wide prediction window. Without this filter, uniformly-sampled
-codes are frequently rare enough, relative to the windowed definition, to
-produce an all-negative task with no learning signal and an undefined
-validation AUROC. If fewer than `num_tasks` candidates pass the filter,
-`generate_tasks` raises a `ValueError` rather than silently returning
-degenerate tasks — raise `candidate_pool_multiplier`, lower
-`min_positive_count`, or lower `num_tasks` in response.
+Every eligible code is windowed-tested (a memory-efficient group-by, not a
+wide pivot, so this scales to the full vocabulary) and only kept as a
+candidate task if it has at least `min_positive_count` in-window positive
+occurrences on the train split. This matters because `min_subjects_per_code`
+(stage 1) only guarantees a code occurred *somewhere* in a subject's lifetime
+record — it says nothing about whether the code falls inside any single
+subject's much narrower `horizon_days`-wide prediction window. On a
+long-tailed clinical vocabulary, only a small fraction of lifetime-frequent
+codes also clear this much narrower windowed bar; without the filter,
+uniformly-sampled codes frequently produce an all-negative task with no
+learning signal and an undefined validation AUROC. If fewer than `num_tasks`
+codes pass the filter, `generate_tasks` raises a `ValueError` rather than
+silently returning degenerate tasks — lower `min_positive_count` or
+`num_tasks` in response.
 
 Output goes to `output_dir/tasks/` and contains one parquet per split plus
 `code_index.json` (mapping task index → code string) and `metadata.json`.

--- a/src/medrap/preprocess/task_generation.py
+++ b/src/medrap/preprocess/task_generation.py
@@ -32,18 +32,25 @@ def _sample_task_codes(
     horizon_days: float = 7.0,
     min_history_days: float = 1.0,
     min_positive_count: int = 10,
-    candidate_pool_multiplier: int = 20,
 ) -> list[str]:
     """Sample ``num_tasks`` codes with enough in-window positive occurrences to be learnable.
 
-    Candidate codes are drawn uniformly at random from codes present in the train
-    split (excluding synthetic ``TIMELINE//`` tokens), then filtered to codes with
-    at least ``min_positive_count`` *in-window* occurrences on the train split
-    (the same windowed-occurrence definition :func:`generate_labels` uses to build
-    labels). This guards against codes that are frequent enough to survive the
-    upstream MEDS-transforms ``min_subjects_per_code`` lifetime filter but almost
-    never fall inside any single subject's randomly-sampled prediction window,
-    which would otherwise produce an all-negative task with no learning signal.
+    Every code present in the train split (excluding synthetic ``TIMELINE//``
+    tokens) is windowed-tested via :func:`_count_in_window_positive_subjects`
+    (a memory-efficient group-by, not a wide pivot, so this scales to testing
+    every eligible code regardless of how many there are), then ``num_tasks``
+    codes are sampled uniformly from those with at least ``min_positive_count``
+    *in-window* occurrences on the train split (the same windowed-occurrence
+    definition :func:`generate_labels` uses to build labels).
+
+    This guards against codes that are frequent enough to survive the upstream
+    MEDS-transforms ``min_subjects_per_code`` lifetime filter but almost never
+    fall inside any single subject's randomly-sampled prediction window, which
+    would otherwise produce an all-negative task with no learning signal. On a
+    real long-tailed clinical vocabulary, only a small fraction of
+    lifetime-frequent codes also clear the much narrower windowed bar, so
+    testing every eligible code (rather than a random subsample) avoids
+    under-sampling the pass rate and failing to find enough tasks.
 
     Args:
         meds_data_dir: Root of a MEDS dataset (``data/train/*.parquet``).
@@ -55,10 +62,6 @@ def _sample_task_codes(
             (must match the value passed to label generation).
         min_positive_count: Minimum number of in-window positive occurrences (on
             the train split) a code must have to be eligible as a task.
-        candidate_pool_multiplier: Number of candidate codes to windowed-test per
-            requested task, before filtering. Larger values cost one (bounded)
-            extra pass over the train split but are more likely to find enough
-            codes with sufficient positive occurrences.
 
     Returns:
         List of ``num_tasks`` code strings, each with >= ``min_positive_count``
@@ -66,7 +69,7 @@ def _sample_task_codes(
 
     Raises:
         ValueError: If no eligible codes are found, or fewer than ``num_tasks``
-            candidates meet the minimum positive-count threshold.
+            eligible codes meet the minimum positive-count threshold.
 
     Examples:
         >>> import tempfile
@@ -85,9 +88,7 @@ def _sample_task_codes(
         ...         rows["code"] += ["DIAG//RARE", "DIAG//COMMON", "TIMELINE//DELTA//years"]
         ...         rows["time"] += [start, start + timedelta(days=5), start + timedelta(days=10)]
         ...     pl.DataFrame(rows).write_parquet(shard_dir / "0.parquet")
-        ...     codes = _sample_task_codes(
-        ...         tmpdir, num_tasks=1, seed=0, min_positive_count=10, candidate_pool_multiplier=20
-        ...     )
+        ...     codes = _sample_task_codes(tmpdir, num_tasks=1, seed=0, min_positive_count=10)
         ...     codes == ["DIAG//COMMON"]
         True
         >>> with tempfile.TemporaryDirectory() as tmpdir:
@@ -103,7 +104,7 @@ def _sample_task_codes(
         ...     _sample_task_codes(tmpdir, num_tasks=1, seed=0, min_positive_count=10)  # doctest: +ELLIPSIS
         Traceback (most recent call last):
             ...
-        ValueError: Only 0/1 candidate codes had >= 10 in-window positive occurrences...
+        ValueError: Only 0/1 eligible codes had >= 10 in-window positive occurrences...
         >>> with tempfile.TemporaryDirectory() as tmpdir:
         ...     shard_dir = Path(tmpdir) / "data" / "train"
         ...     shard_dir.mkdir(parents=True)
@@ -131,47 +132,42 @@ def _sample_task_codes(
     if not eligible:
         raise ValueError(f"No eligible task codes found in {meds_data_dir}/data/train/.")
 
-    rng = np.random.default_rng(seed)
-    pool_size = min(len(eligible), max(num_tasks * candidate_pool_multiplier, num_tasks))
-    candidates = rng.choice(eligible, size=pool_size, replace=False).tolist()
-
-    windowed = generate_labels(meds_data_dir, "train", candidates, horizon_days, min_history_days, seed)
-    if windowed.is_empty():
-        positive_counts = dict.fromkeys(candidates, 0)
-    else:
-        positive_counts = {code: int(windowed[f"task_{i}"].sum()) for i, code in enumerate(candidates)}
-
-    passing = [code for code in candidates if positive_counts[code] >= min_positive_count]
+    positive_counts = _count_in_window_positive_subjects(
+        meds_data_dir, "train", eligible, horizon_days, min_history_days, seed
+    )
+    passing = [code for code in eligible if positive_counts.get(code, 0) >= min_positive_count]
     if len(passing) < num_tasks:
         raise ValueError(
-            f"Only {len(passing)}/{num_tasks} candidate codes had >= {min_positive_count} "
+            f"Only {len(passing)}/{num_tasks} eligible codes had >= {min_positive_count} "
             f"in-window positive occurrences (horizon_days={horizon_days}, "
-            f"min_history_days={min_history_days}) among {len(candidates)} candidates sampled "
-            f"from {len(eligible)} eligible codes. Increase candidate_pool_multiplier, lower "
-            "min_positive_count, or lower num_tasks."
+            f"min_history_days={min_history_days}) among {len(eligible)} eligible codes. "
+            "Lower min_positive_count or num_tasks."
         )
-    return passing[:num_tasks]
+
     rng = np.random.default_rng(seed)
-    chosen = rng.choice(eligible, size=min(num_tasks, len(eligible)), replace=False)
+    chosen = rng.choice(passing, size=num_tasks, replace=False)
     return chosen.tolist()
 
 
-def _generate_labels_shard(
-    shard_path: Path,
-    codes: list[str],
-    horizon_days: float,
-    min_history_days: float,
-    rng: np.random.Generator,
+def _sample_prediction_anchors(
+    df: pl.DataFrame, horizon_days: float, min_history_days: float, rng: np.random.Generator
 ) -> pl.DataFrame | None:
-    """Build multi-task label rows for one shard with a random prediction time per subject.
+    """Sample one random prediction anchor per subject within their valid window.
 
     Prediction time is sampled uniformly from
-    ``[first_event + min_history_days, last_event - horizon_days]``.
-    Subjects whose window is empty are dropped.
+    ``[first_event + min_history_days, last_event - horizon_days]``. Subjects
+    whose window is empty are dropped.
+
+    Args:
+        df: Shard events with ``subject_id`` and ``time`` columns.
+        horizon_days: Days after prediction time to look for code occurrence.
+        min_history_days: Minimum days of history before the prediction anchor.
+        rng: Random generator; consumes one ``rng.random(n_subjects)`` draw.
+
+    Returns:
+        DataFrame with columns ``subject_id``, ``prediction_time``, or ``None``
+        if no subject has a nonempty window.
     """
-    df = pl.read_parquet(shard_path, columns=["subject_id", "time", "code"]).filter(
-        pl.col("time").is_not_null()
-    )
     if df.is_empty():
         return None
 
@@ -198,11 +194,113 @@ def _generate_labels_shard(
     window = (bounds["latest_us"] - bounds["earliest_us"]).to_numpy()
     offsets = (rng.random(len(bounds)) * window).astype(np.int64)
 
-    anchors = (
+    return (
         pl.DataFrame({"subject_id": bounds["subject_id"], "prediction_us": earliest + offsets})
         .with_columns(pl.from_epoch("prediction_us", time_unit="us").alias("prediction_time"))
         .select(["subject_id", "prediction_time"])
     )
+
+
+def _count_in_window_positive_subjects(
+    meds_data_dir: str | Path,
+    split: str,
+    candidate_codes: list[str],
+    horizon_days: float,
+    min_history_days: float,
+    seed: int,
+) -> dict[str, int]:
+    """Count in-window positive subjects per candidate code, without a wide pivot.
+
+    Uses the same windowed-occurrence definition and anchor sampling as
+    :func:`generate_labels` (same seed reproduces identical anchors, since anchor
+    sampling depends only on each subject's event bounds, not on which codes are
+    being tested), but aggregates counts as a long ``code -> count`` table instead
+    of a ``(subject, code)`` wide matrix. This lets it scale to testing every
+    eligible code at once, which a wide pivot cannot do memory-efficiently.
+
+    Args:
+        meds_data_dir: Root of a MEDS dataset.
+        split: Split name (e.g. ``"train"``).
+        candidate_codes: Codes to count.
+        horizon_days: Days after prediction time to look for code occurrence.
+        min_history_days: Minimum days of history before the prediction anchor.
+        seed: Random seed for reproducible anchor sampling.
+
+    Returns:
+        dict mapping code -> number of distinct subjects with an in-window
+        occurrence. Codes with zero in-window occurrences are omitted.
+
+    Examples:
+        >>> import tempfile
+        >>> from datetime import datetime, timedelta
+        >>> with tempfile.TemporaryDirectory() as tmpdir:
+        ...     shard_dir = Path(tmpdir) / "data" / "train"
+        ...     shard_dir.mkdir(parents=True)
+        ...     rows = {"subject_id": [], "code": [], "time": []}
+        ...     for subject_id in range(3):
+        ...         start = datetime(2020, 1, 1) + timedelta(days=subject_id)
+        ...         rows["subject_id"] += [subject_id, subject_id, subject_id]
+        ...         rows["code"] += ["DIAG//RARE", "DIAG//COMMON", "TIMELINE//DELTA//years"]
+        ...         rows["time"] += [start, start + timedelta(days=5), start + timedelta(days=10)]
+        ...     pl.DataFrame(rows).write_parquet(shard_dir / "0.parquet")
+        ...     _count_in_window_positive_subjects(
+        ...         tmpdir,
+        ...         "train",
+        ...         ["DIAG//RARE", "DIAG//COMMON"],
+        ...         horizon_days=7.0,
+        ...         min_history_days=1.0,
+        ...         seed=0,
+        ...     )
+        {'DIAG//COMMON': 3}
+    """
+    shard_dir = Path(meds_data_dir) / "data" / split
+    if not shard_dir.exists():
+        raise FileNotFoundError(f"No shard directory: {shard_dir}")
+
+    rng = np.random.default_rng(seed)
+    counts: dict[str, int] = {}
+    for shard_path in sorted(shard_dir.glob("*.parquet")):
+        df = pl.read_parquet(shard_path, columns=["subject_id", "time", "code"]).filter(
+            pl.col("time").is_not_null()
+        )
+        anchors = _sample_prediction_anchors(df, horizon_days, min_history_days, rng)
+        if anchors is None:
+            continue
+
+        events = df.filter(pl.col("code").is_in(candidate_codes))
+        joined = anchors.join(events, on="subject_id", how="inner").with_columns(
+            ((pl.col("time") - pl.col("prediction_time")).dt.total_seconds() / 86400.0).alias("delta_days")
+        )
+        in_window = joined.filter((pl.col("delta_days") > 0) & (pl.col("delta_days") <= horizon_days))
+        if in_window.is_empty():
+            continue
+
+        grouped = in_window.group_by("code").agg(pl.col("subject_id").n_unique().alias("n"))
+        for code, n in zip(grouped["code"], grouped["n"], strict=False):
+            counts[code] = counts.get(code, 0) + n
+
+    return counts
+
+
+def _generate_labels_shard(
+    shard_path: Path,
+    codes: list[str],
+    horizon_days: float,
+    min_history_days: float,
+    rng: np.random.Generator,
+) -> pl.DataFrame | None:
+    """Build multi-task label rows for one shard with a random prediction time per subject.
+
+    Prediction time is sampled uniformly from
+    ``[first_event + min_history_days, last_event - horizon_days]``.
+    Subjects whose window is empty are dropped.
+    """
+    df = pl.read_parquet(shard_path, columns=["subject_id", "time", "code"]).filter(
+        pl.col("time").is_not_null()
+    )
+    anchors = _sample_prediction_anchors(df, horizon_days, min_history_days, rng)
+    if anchors is None:
+        return None
 
     joined = anchors.join(df, on="subject_id", how="left").with_columns(
         ((pl.col("time") - pl.col("prediction_time")).dt.total_seconds() / 86400.0).alias("delta_days")
@@ -316,7 +414,6 @@ def generate_tasks(
     min_history_days: float = 1.0,
     seed: int = 42,
     min_positive_count: int = 10,
-    candidate_pool_multiplier: int = 20,
     splits: tuple[str, ...] = ("train", "tuning", "held_out"),
 ) -> Path:
     """Create multi-task binary labels from a MEDS cohort.
@@ -335,8 +432,6 @@ def generate_tasks(
         seed: Random seed for task selection and anchor sampling.
         min_positive_count: Minimum in-window positive occurrences (on the train
             split) a candidate code must have to be selected as a task.
-        candidate_pool_multiplier: Number of candidate codes to windowed-test per
-            requested task before filtering by ``min_positive_count``.
         splits: Splits to generate labels for.
 
     Returns:
@@ -376,7 +471,6 @@ def generate_tasks(
         horizon_days=horizon_days,
         min_history_days=min_history_days,
         min_positive_count=min_positive_count,
-        candidate_pool_multiplier=candidate_pool_multiplier,
     )
 
     for split in splits:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -518,7 +518,6 @@ def test_preprocess_entrypoint_runs_with_hydra_overrides(monkeypatch, tmp_path) 
         min_history_days,
         seed,
         min_positive_count,
-        candidate_pool_multiplier,
     ):
         captured["meds_data_dir"] = str(meds_data_dir)
         captured["num_tasks"] = num_tasks
@@ -568,7 +567,6 @@ def test_preprocess_entrypoint_runs_without_tensorized_dir(monkeypatch, tmp_path
         min_history_days,
         seed,
         min_positive_count,
-        candidate_pool_multiplier,
     ):
         Path(output_dir).mkdir(parents=True, exist_ok=True)
         return Path(output_dir)


### PR DESCRIPTION
## Summary

Follow-up to #87, discovered while re-running `mimic_iv_sweep` on the cluster with the fix live: `_sample_task_codes` (as merged in #87) sampled a random subset of `candidate_pool_multiplier * num_tasks` candidates before filtering by `min_positive_count`. On the real MIMIC-IV cohort, only **2/500** candidates (a 20x pool for `num_tasks=25`) passed — confirming the vocabulary is long-tailed enough that a random subsample, even a fairly generous one, is unreliable for finding enough passing codes.

Instead of guessing at a bigger multiplier, this replaces the random-subsample approach with an exhaustive scan:

- `_count_in_window_positive_subjects` computes in-window positive-subject counts for **every** eligible code via a memory-efficient `group_by("code")` (long `code -> count` table), not a wide `(subject, code)` pivot — this scales to the full vocabulary (83k+ codes on the real cohort) without the memory blowup a wide pivot of that width would cause.
- `_sample_task_codes` filters the *entire* eligible set by `min_positive_count`, then samples `num_tasks` uniformly from whatever passes — guaranteeing the best possible candidate pool is considered, not an arbitrary random slice of it.
- Extracted `_sample_prediction_anchors` as a shared helper between the new counting path and the existing wide-pivot label-generation path, so anchor sampling (and its RNG draw sequence) lives in exactly one place and both paths reproduce identical per-subject prediction times for the same seed.
- Removes the `candidate_pool_multiplier` knob added in #87 (merged same day) since it's no longer needed.

## Test plan

- [x] `pytest` — 186 passed
- [x] `ruff check .` / pre-commit (`ruff-format`, `mdformat`, etc.) — clean
- [x] New doctest for `_count_in_window_positive_subjects`; updated doctests for `_sample_task_codes`/`generate_tasks`
- [ ] Re-run `mimic_iv_sweep`'s `generate_labels.sh` on the cluster against the full MIMIC-IV cohort and confirm `_sample_task_codes` now succeeds with real positive rates

🤖 Generated with [Claude Code](https://claude.com/claude-code)