### PR TITLE
feat(retrieve): implement medrap-retrieve CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ medrap-train = "medrap.cli:train_main"
 medrap-eval = "medrap.cli:eval_main"
 medrap-prepare-retrieval-dataset = "medrap.cli:prepare_retrieval_dataset_main"
 medrap-preprocess = "medrap.cli:preprocess_main"
+medrap-retrieve = "medrap.cli:retrieve_main"
 
 [tool.pytest.ini_options]
 testpaths = ["tests", "src/medrap"]

--- a/src/medrap/cli.py
+++ b/src/medrap/cli.py
@@ -14,6 +14,7 @@ from omegaconf import DictConfig, OmegaConf
 from .prepare_retrieval.preparation import prepare_retrieval_dataset_from_config
 from .preprocess.preprocessing import run_meds_pipeline
 from .preprocess.task_generation import generate_tasks
+from .retrieve.retrieval import run_retrieval
 from .train.factory import instantiate_training_module
 
 
@@ -294,6 +295,22 @@ def _prepare_eval_run(cfg: DictConfig) -> Path:
     return output_dir
 
 
+def _prepare_retrieve_run(cfg: DictConfig) -> Path:
+    output_dir = _prepare_output_dir(cfg)
+    config_path = output_dir / "config.yaml"
+
+    if config_path.exists():
+        raise FileExistsError(
+            f"Output directory {output_dir} already contains a saved MedRAP retrieve run. "
+            "Use a different `output_dir`."
+        )
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    OmegaConf.save(cfg, config_path)
+    _save_resolved_config(cfg, output_dir / "resolved_config.yaml")
+    return output_dir
+
+
 def _ensure_lightning_csv_log_dirs(trainer: object) -> None:
     """Create CSVLogger ``log_dir`` trees before the first metrics flush.
 
@@ -433,3 +450,18 @@ def eval_main(cfg: DictConfig) -> int:
         trainer.test(module, datamodule=datamodule)
         return 0
     raise ValueError(f"eval_mode must be 'validate' or 'test'; got {cfg.eval_mode!r}")
+
+
+@hydra.main(version_base=None, config_path="conf", config_name="_retrieve")
+def retrieve_main(cfg: DictConfig) -> None:
+    """Run the Hydra-native retrieval entrypoint."""
+    print(OmegaConf.to_yaml(cfg))
+    output_dir = _prepare_retrieve_run(cfg)
+    checkpoint_path = cfg.checkpoint_path
+    if not checkpoint_path:
+        raise ValueError("checkpoint_path must be set for medrap-retrieve.")
+    module = _load_training_module_checkpoint(cfg, checkpoint_path)
+    bound_cfg = _bind_trainer_paths(cfg, output_dir=output_dir)
+    trainer = instantiate(bound_cfg.training.trainer)
+    output_path = run_retrieval(cfg, module=module, trainer=trainer)
+    print(f"Retrieved documents saved to {output_path}")

--- a/src/medrap/cli.py
+++ b/src/medrap/cli.py
@@ -300,10 +300,13 @@ def _prepare_retrieve_run(cfg: DictConfig) -> Path:
     config_path = output_dir / "config.yaml"
 
     if config_path.exists():
-        raise FileExistsError(
-            f"Output directory {output_dir} already contains a saved MedRAP retrieve run. "
-            "Use a different `output_dir`."
-        )
+        if cfg.do_overwrite:
+            shutil.rmtree(output_dir, ignore_errors=True)
+        else:
+            raise FileExistsError(
+                f"Output directory {output_dir} already contains a saved MedRAP retrieve run. "
+                "Use `do_overwrite=true` or a different `output_dir`."
+            )
 
     output_dir.mkdir(parents=True, exist_ok=True)
     OmegaConf.save(cfg, config_path)

--- a/src/medrap/conf/_retrieve.yaml
+++ b/src/medrap/conf/_retrieve.yaml
@@ -1,0 +1,31 @@
+defaults:
+  - encoder: meds_code
+  - query_projector: sequence_mean
+  - retriever: in_memory
+  - retrieval_encoder: mean_pooled
+  - fusion: replace
+  - pooling: identity
+  - head: linear
+  - training/module: supervised_lightning
+  - training/task: binary_classification
+  - training/loss: binary_bce
+  - training/datamodule: meds
+  - training/trainer: lightning_eval
+  - _self_
+
+head:
+  out_dim: ${training.task.output_dim}
+
+output_dir: ???
+checkpoint_path: ???
+index_dataframe_dir: ???
+splits: [train, tuning, held_out]
+batch_size: 32
+do_overwrite: false
+
+hydra:
+  run:
+    dir: .
+  output_subdir: null
+  job:
+    chdir: false

--- a/src/medrap/configs.py
+++ b/src/medrap/configs.py
@@ -403,6 +403,21 @@ class RAPEvalConfig(PipelineConfig):
 
 
 @dataclass
+class RAPRetrieveConfig(PipelineConfig):
+    """Top-level retrieve config mirroring eval execution fields."""
+
+    head: ComponentConfig = field(default_factory=lambda: LinearHeadConfig(out_dim=1))
+    training: TrainingConfig = field(
+        default_factory=lambda: TrainingConfig(trainer=LightningEvalTrainerConfig())
+    )
+    output_dir: str = MISSING
+    checkpoint_path: str = MISSING
+    index_dataframe_dir: str = MISSING
+    splits: tuple[str, ...] = ("train", "tuning", "held_out")
+    batch_size: int = 32
+
+
+@dataclass
 class RetrievalDatasetIndexConfig:
     """Configuration for offline retrieval artifact columns and FAISS index."""
 

--- a/src/medrap/retrieve/README.md
+++ b/src/medrap/retrieve/README.md
@@ -57,10 +57,12 @@ medrap-retrieve \
     rebuilt from config and the checkpoint `state_dict` is loaded, the same way
     `medrap-eval` does.
 2. **Per-split retrieval** -- because a patient-timepoint's subject belongs to
-    exactly one MEDS split, for each split in `splits` a `MEDSPytorchDataset` is
-    built with `task_labels_dir=index_dataframe_dir` (`meds_torchdata` keeps only
-    the rows belonging to that split), and `trainer.predict()` collects
-    `doc_ids`/`doc_scores` for every row.
+    exactly one MEDS split, for each split in `splits` that has data in the
+    tensorized cohort a `MEDSPytorchDataset` is built with
+    `task_labels_dir=index_dataframe_dir` (`meds_torchdata` keeps only the rows
+    belonging to that split), and `trainer.predict()` collects
+    `doc_ids`/`doc_scores` for every row. A split with no data in the cohort
+    (e.g. no `held_out` split) is skipped rather than treated as an error.
 3. **Left join** -- the per-split results are concatenated and left-joined
     against the *full* input index dataframe, so every input patient-timepoint is
     represented in the output -- with null `doc_ids`/`doc_scores` for any row

--- a/src/medrap/retrieve/README.md
+++ b/src/medrap/retrieve/README.md
@@ -1,9 +1,77 @@
 # medrap.retrieve
 
-Takes a trained model, a retrieval dataset, and an index dataframe for a
-pre-processed MEDS dataset. For each patient-timepoint in the index, retrieves
-the top-K documents (or null) and saves document IDs and scores to disk.
+`medrap-retrieve` takes a trained model checkpoint, a retrieval dataset, and an
+*index dataframe* naming a set of patient-timepoints in an already-preprocessed
+MEDS dataset, and retrieves the configured retriever's top-K documents (or null)
+for each one, saving document IDs and scores to disk.
 
-A different retrieval dataset may be used provided the same embedding model was
-used to build it. The pre-processed MEDS dataset must match the one used during
-training.
+An index dataframe is a directory of parquet file(s) with `subject_id` and
+`prediction_time` columns -- the same shape as the `subject_id, prediction_time, task_0, ...` labels `medrap-preprocess` writes to `output_dir/tasks/`, minus the
+task columns. It is the `meds_torchdata` "task index" concept
+(`MEDSTorchDataConfig(task_labels_dir=...)` without a label column).
+
+## How to run
+
+```bash
+medrap-retrieve \
+  output_dir=<path/to/retrieve_run> \
+  checkpoint_path=<path/to/train_run/checkpoints/best.ckpt> \
+  training/datamodule=meds \
+  training.datamodule.config.tensorized_cohort_dir=<path/to/tensorized> \
+  training.datamodule.config.max_seq_len=512 \
+  index_dataframe_dir=<path/to/index>
+```
+
+`tensorized_cohort_dir`/`max_seq_len` must match the MEDS dataset the checkpoint
+was trained on. `index_dataframe_dir` may be any set of patient-timepoints --
+`medrap-preprocess`'s task labels, a custom cohort, or a different one than was
+used at training time.
+
+### Using a different retrieval dataset
+
+A different retrieval dataset may be used, provided it was built with the same
+embedding model as the one used at training time. Override the retriever's
+dataset path directly:
+
+```bash
+medrap-retrieve \
+  ... \
+  retriever.dataset_path=<path/to/different_retrieval_dataset>
+```
+
+### Key options
+
+| Option                | Default                     | Description                                                                              |
+| --------------------- | --------------------------- | ---------------------------------------------------------------------------------------- |
+| `output_dir`          | **required**                | Directory where the retrieved-document parquet and configs are saved                     |
+| `checkpoint_path`     | **required**                | Path to a `.ckpt` written by `medrap-train`                                              |
+| `index_dataframe_dir` | **required**                | Directory of parquet file(s) with `subject_id`/`prediction_time` columns                 |
+| `splits`              | `[train, tuning, held_out]` | MEDS splits to run retrieval over (a patient-timepoint's subject belongs to exactly one) |
+| `batch_size`          | `32`                        | Batch size for the prediction dataloader                                                 |
+| `do_overwrite`        | `false`                     | Overwrite an existing output directory                                                   |
+
+## What happens under the hood
+
+1. **Model reconstruction** -- the exact trained architecture (encoder / query
+    projector / retriever / retrieval encoder / fusion / pooling / head) is
+    rebuilt from config and the checkpoint `state_dict` is loaded, the same way
+    `medrap-eval` does.
+2. **Per-split retrieval** -- because a patient-timepoint's subject belongs to
+    exactly one MEDS split, for each split in `splits` a `MEDSPytorchDataset` is
+    built with `task_labels_dir=index_dataframe_dir` (`meds_torchdata` keeps only
+    the rows belonging to that split), and `trainer.predict()` collects
+    `doc_ids`/`doc_scores` for every row.
+3. **Left join** -- the per-split results are concatenated and left-joined
+    against the *full* input index dataframe, so every input patient-timepoint is
+    represented in the output -- with null `doc_ids`/`doc_scores` for any row
+    meds_torchdata could not build a sample for (e.g. a subject outside every
+    configured split, or insufficient history before its prediction time).
+
+## Output layout
+
+```
+<output_dir>/
+  config.yaml                  # raw Hydra config as passed
+  resolved_config.yaml         # fully resolved config (all interpolations expanded)
+  retrieved_documents.parquet  # subject_id, prediction_time, doc_ids (list[K]), doc_scores (list[K])
+```

--- a/src/medrap/retrieve/retrieval.py
+++ b/src/medrap/retrieve/retrieval.py
@@ -1,0 +1,185 @@
+"""Retrieval inference: run a trained model over patient-timepoints named by an index dataframe.
+
+For each patient-timepoint (``subject_id``, ``prediction_time`` pair) in an index
+dataframe, retrieves the configured retriever's top-K documents (or null, when
+meds_torchdata cannot build a sample for that patient-timepoint -- e.g. the
+subject falls outside every configured split, or has insufficient history) and
+saves document IDs and scores to disk.
+
+The index dataframe is a directory of parquet file(s) with ``subject_id`` and
+``prediction_time`` columns -- the same "task index" concept meds_torchdata
+already supports via ``MEDSTorchDataConfig(task_labels_dir=...)`` without a label
+column. Because a patient-timepoint's subject belongs to exactly one MEDS split,
+retrieval is run once per split in ``cfg.splits`` and the per-split results are
+concatenated, then left-joined against the full input index dataframe so every
+input row is represented in the output.
+"""
+
+from pathlib import Path
+
+import lightning
+import polars as pl
+from meds_torchdata import MEDSPytorchDataset, MEDSTorchDataConfig
+from omegaconf import DictConfig
+from torch import Tensor
+from torch.utils.data import DataLoader
+
+from ..extraction import collate_prediction_batches
+
+
+def _build_dataset_config(cfg: DictConfig, *, task_labels_dir: str | Path) -> MEDSTorchDataConfig:
+    """Build a retrieval ``MEDSTorchDataConfig`` from the training datamodule's dataset fields.
+
+    Reuses ``cfg.training.datamodule.config``'s ``tensorized_cohort_dir``/
+    ``max_seq_len``/``seq_sampling_strategy`` (the MEDS dataset the checkpoint was
+    trained on must match), but points ``task_labels_dir`` at the retrieve index
+    dataframe rather than whatever training labels ``cfg`` was composed with.
+
+    Examples:
+        >>> import tempfile
+        >>> from hydra import compose, initialize_config_module
+        >>> cohort_dir = tempfile.mkdtemp()
+        >>> index_dir = tempfile.mkdtemp()
+        >>> with initialize_config_module(version_base=None, config_module="medrap.conf"):
+        ...     cfg = compose(
+        ...         config_name="_retrieve",
+        ...         overrides=[
+        ...             "training/datamodule=meds",
+        ...             "output_dir=outputs/demo",
+        ...             "checkpoint_path=outputs/demo/checkpoints/last.ckpt",
+        ...             f"index_dataframe_dir={index_dir}",
+        ...             f"training.datamodule.config.tensorized_cohort_dir={cohort_dir}",
+        ...             "training.datamodule.config.max_seq_len=8",
+        ...         ],
+        ...     )
+        >>> dataset_config = _build_dataset_config(cfg, task_labels_dir=index_dir)
+        >>> dataset_config.max_seq_len
+        8
+        >>> str(dataset_config.task_labels_dir) == index_dir
+        True
+    """
+    dm_config = cfg.training.datamodule.config
+    return MEDSTorchDataConfig(
+        tensorized_cohort_dir=dm_config.tensorized_cohort_dir,
+        max_seq_len=dm_config.max_seq_len,
+        task_labels_dir=str(task_labels_dir),
+        seq_sampling_strategy=dm_config.get("seq_sampling_strategy", "to_end"),
+    )
+
+
+def _squeeze_retrieval_step(tensor: Tensor, *, name: str) -> list:
+    """Convert a ``(N, R, K)`` retrieval tensor to a per-row python list, requiring ``R == 1``.
+
+    Sequence-mode retrieval (``R > 1``, multiple retrieval steps per
+    patient-timepoint) is out of scope for ``medrap-retrieve`` v1, which targets
+    the tabular/single-query-per-timepoint configurations used everywhere else in
+    this codebase's default configs.
+
+    Examples:
+        >>> import torch
+        >>> _squeeze_retrieval_step(torch.LongTensor([[[1, 2]], [[3, 4]]]), name="doc_ids")
+        [[1, 2], [3, 4]]
+        >>> _squeeze_retrieval_step(torch.zeros(2, 2, 3), name="doc_ids")
+        Traceback (most recent call last):
+            ...
+        ValueError: medrap-retrieve only supports single-step retrieval (R=1); got doc_ids with R=2.
+    """
+    if tensor.shape[1] != 1:
+        raise ValueError(
+            f"medrap-retrieve only supports single-step retrieval (R=1); got {name} with R={tensor.shape[1]}."
+        )
+    return tensor[:, 0, :].tolist()
+
+
+def _predict_split(
+    module: lightning.LightningModule,
+    trainer: lightning.Trainer,
+    dataset: MEDSPytorchDataset,
+    *,
+    batch_size: int,
+) -> pl.DataFrame | None:
+    """Run retrieval prediction over one split's dataset and return a per-row result frame.
+
+    Returns ``None`` when the split has no rows (e.g. the index dataframe has no
+    subjects in this split). Otherwise returns a DataFrame with columns
+    ``subject_id``, ``prediction_time``, ``doc_ids`` (``list[K]``), ``doc_scores``
+    (``list[K]``), in the same row order as ``dataset``.
+
+    Raises:
+        ValueError: If the configured retriever does not provide ``doc_ids`` or
+            ``doc_scores``.
+    """
+    if len(dataset) == 0:
+        return None
+
+    dataloader = DataLoader(dataset, batch_size=batch_size, shuffle=False, collate_fn=dataset.collate)
+    predictions = trainer.predict(module, dataloaders=dataloader)
+    collated = collate_prediction_batches(predictions)
+
+    for key in ("doc_ids", "doc_scores"):
+        if key not in collated:
+            raise ValueError(
+                f"medrap-retrieve requires a retriever that provides {key!r}; the configured "
+                "retriever did not produce it."
+            )
+
+    schema = dataset.schema_df.select("subject_id", "prediction_time")
+    return schema.with_columns(
+        pl.Series("doc_ids", _squeeze_retrieval_step(collated["doc_ids"], name="doc_ids")),
+        pl.Series("doc_scores", _squeeze_retrieval_step(collated["doc_scores"], name="doc_scores")),
+    )
+
+
+def run_retrieval(cfg: DictConfig, *, module: lightning.LightningModule, trainer: lightning.Trainer) -> Path:
+    """Retrieve documents for every patient-timepoint in ``cfg.index_dataframe_dir``.
+
+    For each split in ``cfg.splits``, builds a ``MEDSPytorchDataset`` scoped to
+    that split with ``task_labels_dir=cfg.index_dataframe_dir``, runs
+    ``trainer.predict``, and collects ``doc_ids``/``doc_scores`` per
+    patient-timepoint. Results across splits are concatenated (a
+    patient-timepoint's subject belongs to exactly one split) and left-joined
+    against the full input index dataframe, so every input row is represented in
+    the output -- with null ``doc_ids``/``doc_scores`` for any patient-timepoint
+    meds_torchdata could not build a sample for (e.g. a subject outside every
+    configured split, or insufficient history before its prediction time).
+
+    Args:
+        cfg: Resolved ``_retrieve`` config.
+        module: Loaded ``MedRAPSupervisedLightningModule`` (see
+            ``_load_training_module_checkpoint`` in ``medrap.cli``).
+        trainer: Instantiated ``lightning.Trainer`` used for ``trainer.predict``.
+
+    Returns:
+        Path to the written ``retrieved_documents.parquet``.
+    """
+    index_dataframe_dir = Path(cfg.index_dataframe_dir)
+    index_files = sorted(index_dataframe_dir.rglob("*.parquet"))
+    if not index_files:
+        raise FileNotFoundError(f"No parquet files found under index_dataframe_dir={index_dataframe_dir}.")
+    index_df = pl.concat(
+        [pl.read_parquet(fp, columns=["subject_id", "prediction_time"]) for fp in index_files],
+        how="vertical",
+    )
+
+    dataset_config = _build_dataset_config(cfg, task_labels_dir=index_dataframe_dir)
+
+    per_split_frames = []
+    for split in cfg.splits:
+        dataset = MEDSPytorchDataset(dataset_config, split=split)
+        frame = _predict_split(module, trainer, dataset, batch_size=cfg.batch_size)
+        if frame is not None:
+            per_split_frames.append(frame)
+
+    results = (
+        pl.concat(per_split_frames, how="vertical")
+        if per_split_frames
+        else pl.DataFrame(schema={"subject_id": pl.Int64, "prediction_time": pl.Datetime("us")})
+    )
+
+    output = index_df.join(results, on=["subject_id", "prediction_time"], how="left")
+
+    output_dir = Path(cfg.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_path = output_dir / "retrieved_documents.parquet"
+    output.write_parquet(output_path)
+    return output_path

--- a/src/medrap/retrieve/retrieval.py
+++ b/src/medrap/retrieve/retrieval.py
@@ -67,6 +67,29 @@ def _build_dataset_config(cfg: DictConfig, *, task_labels_dir: str | Path) -> ME
     )
 
 
+def _split_has_schema(dataset_config: MEDSTorchDataConfig, split: str) -> bool:
+    """Return whether ``dataset_config``'s tensorized cohort has any shard for ``split``.
+
+    Mirrors the check ``MEDSPytorchDataset.__init__`` performs internally; lets
+    callers skip a split with no shards (e.g. a cohort with no ``held_out`` split)
+    instead of hitting the ``FileNotFoundError`` it raises when no shard matches.
+
+    Examples:
+        >>> import tempfile
+        >>> from pathlib import Path
+        >>> with tempfile.TemporaryDirectory() as tmpdir:
+        ...     schema_dir = Path(tmpdir) / "tokenization" / "schemas" / "train"
+        ...     schema_dir.mkdir(parents=True)
+        ...     _ = (schema_dir / "0.parquet").touch()
+        ...     config = MEDSTorchDataConfig(tensorized_cohort_dir=tmpdir, max_seq_len=8)
+        ...     _split_has_schema(config, "train")
+        ...     _split_has_schema(config, "held_out")
+        True
+        False
+    """
+    return any(shard.startswith(f"{split}/") for shard, _ in dataset_config.schema_fps)
+
+
 def _squeeze_retrieval_step(tensor: Tensor, *, name: str) -> list:
     """Convert a ``(N, R, K)`` retrieval tensor to a per-row python list, requiring ``R == 1``.
 
@@ -97,6 +120,8 @@ def _predict_split(
     dataset: MEDSPytorchDataset,
     *,
     batch_size: int,
+    num_workers: int = 0,
+    pin_memory: bool = False,
 ) -> pl.DataFrame | None:
     """Run retrieval prediction over one split's dataset and return a per-row result frame.
 
@@ -107,12 +132,41 @@ def _predict_split(
 
     Raises:
         ValueError: If the configured retriever does not provide ``doc_ids`` or
-            ``doc_scores``.
+            ``doc_scores``, or if ``trainer`` uses more than one device -- a
+            multi-device ``trainer.predict()`` is not guaranteed to return batches
+            in dataset order, which would silently misalign results against
+            ``dataset.schema_df`` (see ``medrap.extraction.extract_artifacts``,
+            which guards against the same risk).
+
+    Examples:
+        >>> from types import SimpleNamespace
+        >>> class _FakeDataset:
+        ...     def __len__(self):
+        ...         return 3
+        >>> fake_trainer = SimpleNamespace(num_devices=2)
+        >>> _predict_split(None, fake_trainer, _FakeDataset(), batch_size=1)  # doctest: +ELLIPSIS
+        Traceback (most recent call last):
+            ...
+        ValueError: medrap-retrieve requires a single-device trainer...
     """
     if len(dataset) == 0:
         return None
 
-    dataloader = DataLoader(dataset, batch_size=batch_size, shuffle=False, collate_fn=dataset.collate)
+    num_devices = getattr(trainer, "num_devices", 1)
+    if num_devices and num_devices > 1:
+        raise ValueError(
+            "medrap-retrieve requires a single-device trainer; multi-device predict "
+            f"can return rank-interleaved outputs (got num_devices={num_devices})."
+        )
+
+    dataloader = DataLoader(
+        dataset,
+        batch_size=batch_size,
+        shuffle=False,
+        collate_fn=dataset.collate,
+        num_workers=num_workers,
+        pin_memory=pin_memory,
+    )
     predictions = trainer.predict(module, dataloaders=dataloader)
     collated = collate_prediction_batches(predictions)
 
@@ -162,18 +216,33 @@ def run_retrieval(cfg: DictConfig, *, module: lightning.LightningModule, trainer
     )
 
     dataset_config = _build_dataset_config(cfg, task_labels_dir=index_dataframe_dir)
+    dm_cfg = cfg.training.datamodule
+    num_workers = dm_cfg.get("num_workers", None) or 0
+    pin_memory = bool(dm_cfg.get("pin_memory", None) or False)
 
     per_split_frames = []
     for split in cfg.splits:
+        if not _split_has_schema(dataset_config, split):
+            continue
         dataset = MEDSPytorchDataset(dataset_config, split=split)
-        frame = _predict_split(module, trainer, dataset, batch_size=cfg.batch_size)
+        frame = _predict_split(
+            module,
+            trainer,
+            dataset,
+            batch_size=cfg.batch_size,
+            num_workers=num_workers,
+            pin_memory=pin_memory,
+        )
         if frame is not None:
             per_split_frames.append(frame)
 
     results = (
         pl.concat(per_split_frames, how="vertical")
         if per_split_frames
-        else pl.DataFrame(schema={"subject_id": pl.Int64, "prediction_time": pl.Datetime("us")})
+        else index_df.clear().with_columns(
+            pl.lit(None, dtype=pl.List(pl.Int64)).alias("doc_ids"),
+            pl.lit(None, dtype=pl.List(pl.Float64)).alias("doc_scores"),
+        )
     )
 
     output = index_df.join(results, on=["subject_id", "prediction_time"], how="left")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -252,6 +252,97 @@ def test_retrieve_entrypoint_runs_end_to_end(
     assert known_rows["doc_scores"].null_count() == 0
 
 
+def test_retrieve_entrypoint_supports_do_overwrite(
+    tmp_path,
+    tensorized_MEDS_dataset_with_task,
+    tensorized_MEDS_dataset_with_index,
+) -> None:
+    cohort_dir, task_root_dir, task_name = tensorized_MEDS_dataset_with_task
+    _, index_root_dir, index_name = tensorized_MEDS_dataset_with_index
+    task_labels_dir = task_root_dir / task_name
+    index_dataframe_dir = index_root_dir / index_name
+
+    train_dir = tmp_path / "train"
+    assert (
+        _run_train_cli(
+            [
+                f"output_dir={train_dir}",
+                "training/datamodule=meds",
+                f"training.datamodule.config.tensorized_cohort_dir={cohort_dir}",
+                "training.datamodule.config.max_seq_len=10",
+                f"training.datamodule.config.task_labels_dir={task_labels_dir}",
+            ]
+        )
+        == 0
+    )
+    checkpoint_path = train_dir / "checkpoints" / "last.ckpt"
+
+    retrieve_overrides = [
+        f"output_dir={tmp_path / 'retrieve'}",
+        f"checkpoint_path={checkpoint_path}",
+        "training/datamodule=meds",
+        f"training.datamodule.config.tensorized_cohort_dir={cohort_dir}",
+        "training.datamodule.config.max_seq_len=10",
+        f"index_dataframe_dir={index_dataframe_dir}",
+    ]
+    assert _run_retrieve_cli(retrieve_overrides) == 0
+
+    _assert_cli_failure(
+        lambda: _run_retrieve_cli(retrieve_overrides),
+        allowed_exceptions=(SystemExit, FileExistsError),
+        expected_message="already contains a saved MedRAP retrieve run",
+    )
+
+    assert _run_retrieve_cli([*retrieve_overrides, "do_overwrite=true"]) == 0
+
+
+def test_retrieve_entrypoint_skips_split_with_no_schema(
+    tmp_path,
+    tensorized_MEDS_dataset_with_task,
+    tensorized_MEDS_dataset_with_index,
+) -> None:
+    """A split name with no corresponding schema shard is skipped, not a crash."""
+    cohort_dir, task_root_dir, task_name = tensorized_MEDS_dataset_with_task
+    _, index_root_dir, index_name = tensorized_MEDS_dataset_with_index
+    task_labels_dir = task_root_dir / task_name
+    index_dataframe_dir = index_root_dir / index_name
+
+    train_dir = tmp_path / "train"
+    assert (
+        _run_train_cli(
+            [
+                f"output_dir={train_dir}",
+                "training/datamodule=meds",
+                f"training.datamodule.config.tensorized_cohort_dir={cohort_dir}",
+                "training.datamodule.config.max_seq_len=10",
+                f"training.datamodule.config.task_labels_dir={task_labels_dir}",
+            ]
+        )
+        == 0
+    )
+    checkpoint_path = train_dir / "checkpoints" / "last.ckpt"
+
+    retrieve_dir = tmp_path / "retrieve"
+    assert (
+        _run_retrieve_cli(
+            [
+                f"output_dir={retrieve_dir}",
+                f"checkpoint_path={checkpoint_path}",
+                "training/datamodule=meds",
+                f"training.datamodule.config.tensorized_cohort_dir={cohort_dir}",
+                "training.datamodule.config.max_seq_len=10",
+                f"index_dataframe_dir={index_dataframe_dir}",
+                "splits=[train,tuning,held_out,imaginary_split]",
+            ]
+        )
+        == 0
+    )
+
+    result = pl.read_parquet(retrieve_dir / "retrieved_documents.parquet")
+    assert result["doc_ids"].null_count() == 0
+    assert result["doc_scores"].null_count() == 0
+
+
 def test_prepare_train_run_overwrite_removes_stale_files(tmp_path: Path) -> None:
     output_dir = tmp_path / "train"
     output_dir.mkdir()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,8 +1,10 @@
 import sys
 import tomllib
+from datetime import datetime
 from pathlib import Path
 from types import SimpleNamespace
 
+import polars as pl
 import pytest
 from lightning.pytorch import Trainer
 from lightning.pytorch.loggers import CSVLogger
@@ -10,7 +12,13 @@ from omegaconf import OmegaConf
 from omegaconf.errors import MissingMandatoryValue
 
 import medrap.cli as cli
-from medrap.cli import eval_main, prepare_retrieval_dataset_main, preprocess_main, train_main
+from medrap.cli import (
+    eval_main,
+    prepare_retrieval_dataset_main,
+    preprocess_main,
+    retrieve_main,
+    train_main,
+)
 
 TINY_SENTENCE_TRANSFORMER_MODEL = "sentence-transformers-testing/stsb-bert-tiny-safetensors"
 
@@ -41,6 +49,10 @@ def _run_train_cli(overrides: list[str]) -> int:
 
 def _run_eval_cli(overrides: list[str]) -> int:
     return _run_hydra_entrypoint(eval_main, "medrap-eval", overrides)
+
+
+def _run_retrieve_cli(overrides: list[str]) -> int:
+    return _run_hydra_entrypoint(retrieve_main, "medrap-retrieve", overrides)
 
 
 def _run_prepare_retrieval_dataset_cli(overrides: list[str]) -> int:
@@ -92,6 +104,7 @@ def test_flat_entrypoint_scripts_are_registered() -> None:
     assert medrap_scripts["medrap-eval"] == "medrap.cli:eval_main"
     assert medrap_scripts["medrap-prepare-retrieval-dataset"] == "medrap.cli:prepare_retrieval_dataset_main"
     assert medrap_scripts["medrap-preprocess"] == "medrap.cli:preprocess_main"
+    assert medrap_scripts["medrap-retrieve"] == "medrap.cli:retrieve_main"
 
 
 def test_prepare_retrieval_dataset_entrypoint_runs_with_hydra_overrides(monkeypatch, tmp_path) -> None:
@@ -148,6 +161,95 @@ def test_eval_entrypoint_requires_checkpoint_path(tmp_path) -> None:
         allowed_exceptions=(SystemExit, MissingMandatoryValue, ValueError),
         expected_message="checkpoint_path",
     )
+
+
+def test_retrieve_entrypoint_requires_checkpoint_path(tmp_path) -> None:
+    _assert_cli_failure(
+        lambda: _run_retrieve_cli(
+            [
+                f"output_dir={tmp_path / 'retrieve'}",
+                "training/datamodule=synthetic",
+                f"index_dataframe_dir={tmp_path / 'index'}",
+            ]
+        ),
+        allowed_exceptions=(SystemExit, MissingMandatoryValue, ValueError),
+        expected_message="checkpoint_path",
+    )
+
+
+def test_retrieve_entrypoint_runs_end_to_end(
+    tmp_path,
+    tensorized_MEDS_dataset_with_task,
+    tensorized_MEDS_dataset_with_index,
+) -> None:
+    cohort_dir, task_root_dir, task_name = tensorized_MEDS_dataset_with_task
+    _, index_root_dir, index_name = tensorized_MEDS_dataset_with_index
+    task_labels_dir = task_root_dir / task_name
+    index_dataframe_dir = index_root_dir / index_name
+
+    train_dir = tmp_path / "train"
+    assert (
+        _run_train_cli(
+            [
+                f"output_dir={train_dir}",
+                "training/datamodule=meds",
+                f"training.datamodule.config.tensorized_cohort_dir={cohort_dir}",
+                "training.datamodule.config.max_seq_len=10",
+                f"training.datamodule.config.task_labels_dir={task_labels_dir}",
+            ]
+        )
+        == 0
+    )
+    checkpoint_path = train_dir / "checkpoints" / "last.ckpt"
+    assert checkpoint_path.exists()
+
+    original_index_df = pl.concat(
+        [
+            pl.read_parquet(fp, columns=["subject_id", "prediction_time"])
+            for fp in sorted(index_dataframe_dir.rglob("*.parquet"))
+        ],
+        how="vertical",
+    )
+
+    # Add a subject outside every split in the tensorized cohort, so its retrieval
+    # row must come back null instead of being silently dropped.
+    extra_index_dir = tmp_path / "index_with_extra"
+    extra_index_dir.mkdir()
+    for fp in index_dataframe_dir.rglob("*.parquet"):
+        pl.read_parquet(fp).write_parquet(extra_index_dir / fp.name)
+    pl.DataFrame({"subject_id": [999999], "prediction_time": [datetime(2020, 1, 1)]}).write_parquet(
+        extra_index_dir / "extra.parquet"
+    )
+
+    retrieve_dir = tmp_path / "retrieve"
+    assert (
+        _run_retrieve_cli(
+            [
+                f"output_dir={retrieve_dir}",
+                f"checkpoint_path={checkpoint_path}",
+                "training/datamodule=meds",
+                f"training.datamodule.config.tensorized_cohort_dir={cohort_dir}",
+                "training.datamodule.config.max_seq_len=10",
+                f"index_dataframe_dir={extra_index_dir}",
+            ]
+        )
+        == 0
+    )
+
+    output_path = retrieve_dir / "retrieved_documents.parquet"
+    assert output_path.exists()
+    result = pl.read_parquet(output_path)
+
+    assert set(result.columns) == {"subject_id", "prediction_time", "doc_ids", "doc_scores"}
+    assert result.height == original_index_df.height + 1
+
+    extra_row = result.filter(pl.col("subject_id") == 999999)
+    assert extra_row["doc_ids"].to_list() == [None]
+    assert extra_row["doc_scores"].to_list() == [None]
+
+    known_rows = result.filter(pl.col("subject_id") != 999999)
+    assert known_rows["doc_ids"].null_count() == 0
+    assert known_rows["doc_scores"].null_count() == 0
 
 
 def test_prepare_train_run_overwrite_removes_stale_files(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Implements the `medrap.retrieve` module (previously a README-only stub): a new `medrap-retrieve` CLI command that takes a trained checkpoint and an index dataframe of patient-timepoints, and retrieves the configured retriever's top-K documents (or null) for each one.
- The index dataframe is meds_torchdata's existing "task index" concept (`subject_id`/`prediction_time` parquet, no label column) — no new format was invented.
- Reuses existing machinery rather than reimplementing it: `instantiate_training_module`/`_load_training_module_checkpoint` (same model reconstruction as `medrap-eval`) and `medrap.extraction.collate_prediction_batches` (concatenating `trainer.predict()` batches).
- Because a patient-timepoint's subject belongs to exactly one MEDS split, retrieval runs once per split and results are left-joined against the full input index dataframe, so every input row is represented in the output — with null `doc_ids`/`doc_scores` for any patient-timepoint meds_torchdata couldn't build a sample for.

## Test plan
- [x] `pytest -q` (full suite, 190 passed) with `.venv/bin` on `PATH` (needed for the `MTD_preprocess` subprocess fixture)
- [x] New doctests in `retrieve/retrieval.py` (`_squeeze_retrieval_step`, `_build_dataset_config`)
- [x] New `tests/test_cli.py::test_retrieve_entrypoint_runs_end_to_end` — trains a tiny model on a real tensorized MEDS fixture, runs `medrap-retrieve` against it, and asserts the output parquet has one row per input index row (including a deliberately out-of-cohort subject verifying the null left-join behavior)
- [x] New `tests/test_cli.py::test_retrieve_entrypoint_requires_checkpoint_path`
- [x] `ruff check`/`ruff format --check` and `pre-commit run` (mdformat, docformatter, prettier, etc.) on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)