### PR TITLE
fix(model): add marginalized_output_mode=binary for independent multi-task targets

### DIFF
--- a/src/medrap/conf/_train.yaml
+++ b/src/medrap/conf/_train.yaml
@@ -24,6 +24,7 @@ seed: 42
 
 marginalized_retrieval: false
 marginalized_score_similarity: dot
+marginalized_output_mode: categorical # categorical | binary
 
 # Used when training/trainer=lightning_wandb (ignored otherwise).
 wandb_project: medrap

--- a/src/medrap/configs.py
+++ b/src/medrap/configs.py
@@ -345,6 +345,7 @@ class PipelineConfig:
     head: ComponentConfig = field(default_factory=LinearHeadConfig)
     marginalized_retrieval: bool = False
     marginalized_score_similarity: str = "dot"
+    marginalized_output_mode: str = "categorical"  # "categorical" | "binary"
 
 
 @dataclass

--- a/src/medrap/model/model.py
+++ b/src/medrap/model/model.py
@@ -1,5 +1,6 @@
 """RAP API model orchestration."""
 
+import torch
 from meds_torchdata import MEDSTorchBatch
 from torch import Tensor, nn
 from torch.nn import functional as nn_functional
@@ -10,9 +11,75 @@ from .retrieval_scoring import differentiable_retrieval_scores
 
 
 def _marginal_class_probabilities(per_doc_logits: Tensor, doc_scores: Tensor) -> Tensor:
+    """Marginalize a single ``C``-way mutually-exclusive class distribution over documents.
+
+    Softmaxes ``per_doc_logits`` over its last (class) dimension, so the ``C``
+    output probabilities compete and sum to 1 -- correct for a single
+    ``MarginalizedBinaryClassificationTask`` (``C=2``: positive vs. negative),
+    but wrong for ``C`` *independent* binary tasks, where one task being likely
+    says nothing about another. Use :func:`_marginal_binary_logits` for that case
+    (see ``RetrievalAugmentedModel``'s ``marginalized_output_mode``).
+    """
     p_ret = nn_functional.softmax(doc_scores, dim=-1)
     p_pred = nn_functional.softmax(per_doc_logits, dim=-1)
     return (p_ret.unsqueeze(-1) * p_pred).sum(dim=1)
+
+
+def _marginal_binary_logits(per_doc_logits: Tensor, doc_scores: Tensor) -> Tensor:
+    """Marginalize ``C`` independent per-task binary probabilities over documents.
+
+    For each of the ``C`` tasks independently, marginalizes
+    ``sigmoid(per_doc_logits)`` over the ``K`` retrieved documents, weighted by
+    ``softmax(doc_scores)`` over the *document* dimension only -- unlike
+    :func:`_marginal_class_probabilities`, tasks never compete for probability
+    mass. Returns the corresponding logit (``torch.logit`` of the marginal
+    probability) so the result stays compatible with BCE-based losses/metrics
+    that expect independent per-task logits.
+
+    Examples:
+        >>> logits = torch.zeros(2, 3, 4)
+        >>> scores = torch.zeros(2, 3)
+        >>> _marginal_binary_logits(logits, scores).shape
+        torch.Size([2, 4])
+        >>> torch.allclose(_marginal_binary_logits(logits, scores), torch.zeros(2, 4))
+        True
+
+        Unlike the categorical marginalization, per-task probabilities don't
+        need to sum to 1:
+
+        >>> logits = torch.FloatTensor([[[3.0, 3.0, 3.0]]])
+        >>> scores = torch.zeros(1, 1)
+        >>> probs = torch.sigmoid(_marginal_binary_logits(logits, scores))
+        >>> bool((probs.sum(dim=-1) > 1.5).all())
+        True
+
+        With ``K=1`` (a single retrieved document), marginalization is a
+        no-op and the output logit equals the input logit:
+
+        >>> logits = torch.FloatTensor([[[1.5, -2.0]]])
+        >>> scores = torch.zeros(1, 1)
+        >>> torch.allclose(_marginal_binary_logits(logits, scores), logits.squeeze(1), atol=1e-5)
+        True
+
+        ``sigmoid`` of the result matches ``MultiTaskBCEMarginalizedLoss``'s
+        own (log-space) marginal-probability computation exactly -- this is
+        the same quantity the loss already trains against, just now also
+        exposed as ``predictions.logits`` for AUROC/accuracy/inference:
+
+        >>> import torch.nn.functional as F
+        >>> _ = torch.manual_seed(0)
+        >>> per_doc = torch.randn(4, 5, 3)
+        >>> scores = torch.randn(4, 5)
+        >>> our_probs = torch.sigmoid(_marginal_binary_logits(per_doc, scores))
+        >>> log_p_ret = F.log_softmax(scores, dim=-1).unsqueeze(-1)
+        >>> loss_probs = torch.logsumexp(log_p_ret + F.logsigmoid(per_doc), dim=1).exp()
+        >>> torch.allclose(our_probs, loss_probs, atol=1e-5)
+        True
+    """
+    p_ret = nn_functional.softmax(doc_scores, dim=-1)
+    p_pos = (p_ret.unsqueeze(-1) * per_doc_logits.sigmoid()).sum(dim=1)
+    eps = torch.finfo(p_pos.dtype).eps
+    return torch.logit(p_pos.clamp(eps, 1.0 - eps))
 
 
 class RetrievalAugmentedModel(nn.Module):
@@ -36,6 +103,16 @@ class RetrievalAugmentedModel(nn.Module):
         marginalized_score_similarity: ``\"dot\"`` or ``\"cosine\"`` for recomputed
             query--key scores (should match the retriever's notion of similarity
             when possible).
+        marginalized_output_mode: ``\"categorical\"`` (default) marginalizes a
+            single ``C``-way mutually-exclusive class distribution with
+            ``softmax`` over the class dimension -- correct for
+            :class:`MarginalizedBinaryClassificationTask` (``C=2``: positive vs.
+            negative), wrong for ``C`` independent binary tasks.
+            ``\"binary\"`` marginalizes each of the ``C`` tasks' ``sigmoid``
+            probabilities independently (softmax only over the retrieved
+            *documents*) and returns BCE-compatible logits -- use this for
+            :class:`MultiTaskBinaryClassificationTask`
+            (``training/loss=multitask_binary_bce_marginalized``).
     """
 
     def __init__(
@@ -50,8 +127,14 @@ class RetrievalAugmentedModel(nn.Module):
         head: nn.Module,
         marginalized_retrieval: bool = False,
         marginalized_score_similarity: str = "dot",
+        marginalized_output_mode: str = "categorical",
     ) -> None:
         super().__init__()
+        if marginalized_output_mode not in ("categorical", "binary"):
+            raise ValueError(
+                "marginalized_output_mode must be 'categorical' or 'binary', "
+                f"got {marginalized_output_mode!r}"
+            )
         self.encoder = encoder
         self.query_projector = query_projector
         self.retriever = retriever
@@ -61,6 +144,7 @@ class RetrievalAugmentedModel(nn.Module):
         self.head = head
         self.marginalized_retrieval = bool(marginalized_retrieval)
         self.marginalized_score_similarity = str(marginalized_score_similarity)
+        self.marginalized_output_mode = str(marginalized_output_mode)
 
     def forward(self, batch: MEDSTorchBatch) -> ModelOutput:
         """Run the end-to-end RAP pipeline.
@@ -193,6 +277,60 @@ class RetrievalAugmentedModel(nn.Module):
             (2, 2)
             >>> tuple(out_perdoc.metadata["per_doc_logits"].shape)
             (2, 2, 2)
+
+        ``marginalized_output_mode="binary"`` for independent multi-task
+        targets (e.g. :class:`MultiTaskBinaryClassificationTask`): same
+        per-document fusion setup, but ``logits`` no longer sums to a
+        probability distribution across tasks -- each task's probability is
+        independent:
+
+            >>> m_binary = RetrievalAugmentedModel(
+            ...     encoder=MEDSCodeEncoder(),
+            ...     query_projector=SequenceMeanQueryProjector(in_dim=1, out_dim=4),
+            ...     retriever=InMemoryRetriever(
+            ...         doc_key_embeddings=torch.FloatTensor(
+            ...             [[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0]]
+            ...         ),
+            ...         doc_tokens=torch.LongTensor([[1, 2], [3, 4], [5, 6]]),
+            ...         doc_attention_mask=torch.BoolTensor([[True, True], [True, True], [True, True]]),
+            ...         k=2,
+            ...     ),
+            ...     retrieval_encoder=TokenFeatureRetrievalEncoder(vocab_size=8, embedding_dim=6),
+            ...     fusion=PerDocCrossAttentionFusion(
+            ...         d_model=4, num_heads=2, ff_dim=8, num_layers=1, d_in_patient=1, d_in_doc=6
+            ...     ),
+            ...     pooling=IdentityPooling(),
+            ...     head=LinearHead(in_dim=4, out_dim=3),
+            ...     marginalized_retrieval=True,
+            ...     marginalized_output_mode="binary",
+            ... )
+            >>> out_binary = m_binary(mb)
+            >>> tuple(out_binary.logits.shape)
+            (2, 3)
+            >>> probs = torch.sigmoid(out_binary.logits)
+            >>> bool((probs.sum(dim=-1) - 1.0).abs().gt(1e-4).any())
+            True
+
+        Invalid ``marginalized_output_mode`` is rejected eagerly, at
+        construction time:
+
+            >>> RetrievalAugmentedModel(
+            ...     encoder=MEDSCodeEncoder(),
+            ...     query_projector=SequenceMeanQueryProjector(in_dim=1, out_dim=4),
+            ...     retriever=InMemoryRetriever(
+            ...         doc_key_embeddings=torch.FloatTensor([[1.0, 0.0, 0.0, 0.0]]),
+            ...         doc_tokens=torch.LongTensor([[1, 2]]),
+            ...         doc_attention_mask=torch.BoolTensor([[True, True]]),
+            ...     ),
+            ...     retrieval_encoder=MeanPooledRetrievalEncoder(vocab_size=8, embedding_dim=2),
+            ...     fusion=ReplaceFusion(),
+            ...     pooling=IdentityPooling(),
+            ...     head=LinearHead(in_dim=2, out_dim=2),
+            ...     marginalized_output_mode="invalid",
+            ... )  # doctest: +ELLIPSIS
+            Traceback (most recent call last):
+                ...
+            ValueError: marginalized_output_mode must be 'categorical' or 'binary'...
 
         Marginalized retrieval validation errors:
 
@@ -364,8 +502,11 @@ class RetrievalAugmentedModel(nn.Module):
                     "differentiable scores must be (B, K) matching fused documents; "
                     f"got scores={tuple(doc_scores.shape)}, K={k_docs}"
                 )
-            marginal_probs = _marginal_class_probabilities(per_doc_logits, doc_scores)
-            logits = marginal_probs.clamp_min(1e-8).log()
+            if self.marginalized_output_mode == "binary":
+                logits = _marginal_binary_logits(per_doc_logits, doc_scores)
+            else:
+                marginal_probs = _marginal_class_probabilities(per_doc_logits, doc_scores)
+                logits = marginal_probs.clamp_min(1e-8).log()
             meta["per_doc_logits"] = per_doc_logits
             meta["differentiable_doc_scores"] = doc_scores
         else:

--- a/src/medrap/train/factory.py
+++ b/src/medrap/train/factory.py
@@ -47,6 +47,18 @@ def instantiate_training_module(config: Any) -> MedRAPSupervisedLightningModule:
         >>> targets = module.task.extract_targets(batch)
         >>> module.loss_fn(out, targets).ndim
         0
+
+        ``marginalized_output_mode`` is threaded through to the plain model
+        (defaults to ``"categorical"``; see ``RetrievalAugmentedModel`` for
+        why independent multi-task targets need ``"binary"`` instead):
+
+        >>> module.model.marginalized_output_mode
+        'categorical'
+        >>> binary_module = instantiate_training_module(
+        ...     RAPTrainConfig(output_dir="outputs/demo", marginalized_output_mode="binary")
+        ... )
+        >>> binary_module.model.marginalized_output_mode
+        'binary'
     """
     plain_model = RetrievalAugmentedModel(
         encoder=instantiate_any(config.encoder),
@@ -58,6 +70,7 @@ def instantiate_training_module(config: Any) -> MedRAPSupervisedLightningModule:
         head=instantiate_any(config.head),
         marginalized_retrieval=bool(getattr(config, "marginalized_retrieval", False)),
         marginalized_score_similarity=str(getattr(config, "marginalized_score_similarity", "dot")),
+        marginalized_output_mode=str(getattr(config, "marginalized_output_mode", "categorical")),
     )
     task = instantiate_any(config.training.task)
     loss_fn = instantiate_any(config.training.loss)


### PR DESCRIPTION
## Summary
- `RetrievalAugmentedModel`'s marginalized-retrieval `logits` always went through `_marginal_class_probabilities`: a `softmax` over the class/task dimension. That's correct for a single mutually-exclusive `C`-way task (`MarginalizedBinaryClassificationTask`, `C=2`: positive vs. negative), but wrong for `MultiTaskBinaryClassificationTask`'s `N` *independent* binary tasks — softmax forces them to compete for probability mass, corrupting `predictions.logits` and everything downstream that reads it: `val/auroc`, `task.metrics()` accuracy, `prediction/*` diagnostics, and `medrap-predict-probabilities`/`medrap-eval` output.
- `MultiTaskBCEMarginalizedLoss` already computes the correct quantity (independent per-task sigmoid, marginalized over documents only), but reads it from `metadata["per_doc_logits"]`/`differentiable_doc_scores` directly, bypassing `logits` entirely — so training itself was never affected by this bug, only every metric and inference path built on top of `logits`.
- Adds `marginalized_output_mode: "categorical" | "binary"` to `RetrievalAugmentedModel`. `"categorical"` (unchanged default — no existing run's behavior changes unless it opts in) keeps the current softmax-over-tasks path. `"binary"` uses a new `_marginal_binary_logits`: independent per-task sigmoid marginalized over the `K` retrieved documents only (softmax over documents, never over tasks), converted back to a BCE-compatible logit via `torch.logit`.
- Wires `marginalized_output_mode` through `configs.py` (`PipelineConfig`), `train/factory.py`, and `_train.yaml`.

## Where this came from
This fix already existed once, on an unmerged personal branch: `McDermottHealthAI/MedRAP@bdf0696` ("Add per-document cross-attention marginalization"), which added the same `marginalized_output_mode` flag and a `_marginal_binary_logits` implementation. A training script on that branch used `marginalized_output_mode=binary` and got a genuinely good, uniform marginalized-multitask AUROC on W&B (`mt25-rope-cross-attn-marginalized`, mean 0.916, all 25 tasks scoring 0.82–0.97, no collapse) — unlike this repo's current `mimic_iv_sweep`/`mimic_iv_sweep_frequent` `marginalized-n{N}` runs, which show exactly the bimodal near-0/near-1 per-task AUROC pattern the softmax-competition bug predicts. That branch never merged; this PR ports the same fix (same math, no renaming) into the current `model/model.py` layout.

## Test plan
- [x] `pytest --doctest-modules src/medrap/model/model.py` — new doctests cover: `_marginal_binary_logits` shape/K=1-identity/non-sum-to-1 behavior, an end-to-end `RetrievalAugmentedModel.forward()` example with `marginalized_output_mode="binary"`, and eager validation of an invalid mode string at construction time.
- [x] A doctest proves `sigmoid(_marginal_binary_logits(...))` is numerically identical (`atol=1e-5`) to `MultiTaskBCEMarginalizedLoss`'s own log-space marginal-probability computation — i.e. `predictions.logits` under `"binary"` mode is provably the same quantity the loss already trains against, not a new approximation.
- [x] `pytest --doctest-modules src/medrap/train/factory.py` — confirms `marginalized_output_mode` is threaded from config (`RAPTrainConfig`) through to the instantiated `RetrievalAugmentedModel`, defaulting to `"categorical"`.
- [x] Full suite: `pytest -q` (194 passed).
- [x] `ruff check`/`ruff format --check` on all changed files.

## Next step (not in this PR)
Once merged, re-run `mimic_iv_sweep_frequent/scripts/sweep_marginalized_n1248.sh` with `marginalized_output_mode=binary` added to the override list, and compare against the existing `marginalized-frequent-n{N}-*` runs (categorical mode) and `retrieval-frequent-n{N}-*`/`patient-only-frequent-n{N}-*` baselines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)