### PR TITLE
fix(eval): declare marginalized_*/wandb_* fields on _eval.yaml

### DIFF
--- a/src/medrap/conf/_eval.yaml
+++ b/src/medrap/conf/_eval.yaml
@@ -20,6 +20,14 @@ output_dir: ???
 checkpoint_path: ???
 eval_mode: validate
 
+marginalized_retrieval: false
+marginalized_score_similarity: dot
+marginalized_output_mode: categorical # categorical | binary
+
+# Used when training/trainer=lightning_wandb (ignored otherwise).
+wandb_project: medrap
+wandb_run_name: medrap-eval
+
 hydra:
   run:
     dir: .

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -699,6 +699,54 @@ def test_run_eval_rejects_unknown_eval_mode(tmp_path, monkeypatch: pytest.Monkey
     )
 
 
+def test_run_eval_accepts_marginalized_and_wandb_overrides(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``_eval.yaml`` must declare marginalized_*/wandb_* so these overrides compose.
+
+    Regression test: these keys previously existed only in ``_train.yaml``, so
+    overriding them for ``medrap-eval`` raised
+    ``ConfigCompositionException: Could not override 'marginalized_retrieval'``
+    before it was added here too (needed so a checkpoint trained with
+    ``marginalized_output_mode=binary`` can be reloaded for eval, and so
+    ``training/trainer=lightning_wandb`` can resolve ``${wandb_run_name}``).
+    """
+
+    class StubTrainer:
+        loggers: list = []  # noqa: RUF012
+
+        def validate(self, module, datamodule=None) -> None:
+            pass
+
+        def test(self, module, datamodule=None) -> None:
+            pass
+
+    captured_cfg = {}
+
+    def _fake_load(cfg, checkpoint_path):
+        captured_cfg["marginalized_output_mode"] = cfg.marginalized_output_mode
+        return object()
+
+    monkeypatch.setattr(cli, "_load_training_module_checkpoint", _fake_load)
+    monkeypatch.setattr(cli, "instantiate", lambda trainer_cfg: StubTrainer())
+    monkeypatch.setattr(cli, "_instantiate_datamodule", lambda cfg: object())
+    monkeypatch.setattr(cli, "_ensure_lightning_csv_log_dirs", lambda trainer: None)
+
+    result = _run_eval_cli(
+        [
+            f"output_dir={tmp_path / 'eval'}",
+            f"checkpoint_path={tmp_path / 'model.ckpt'}",
+            "eval_mode=validate",
+            "training/datamodule=synthetic",
+            "marginalized_retrieval=true",
+            "marginalized_output_mode=binary",
+            "training/trainer=lightning_wandb",
+            "wandb_run_name=test-eval-run",
+        ]
+    )
+
+    assert result == 0
+    assert captured_cfg["marginalized_output_mode"] == "binary"
+
+
 def test_preprocess_entrypoint_runs_with_hydra_overrides(monkeypatch, tmp_path) -> None:
     captured = {}
 


### PR DESCRIPTION
## Summary
- `medrap-eval` couldn't reload a checkpoint trained with `marginalized_retrieval=true` or `marginalized_output_mode=binary` — `_eval.yaml` never declared those keys (only `_train.yaml` did), and Hydra's struct-mode composition rejects an override for a key that doesn't already exist: `ConfigCompositionException: Could not override 'marginalized_retrieval'`.
- Same problem blocked `training/trainer=lightning_wandb` for eval — its `${wandb_project}`/`${wandb_run_name}` interpolations had nothing to resolve against on `_eval.yaml`.
- Adds the same three `marginalized_*` fields and two `wandb_*` fields `_train.yaml` already has, defaulted identically (`marginalized_retrieval=false`, `marginalized_output_mode=categorical`, `wandb_project=medrap`). Lets `medrap-eval` both reload marginalized checkpoints for evaluation and log eval results to W&B via `training/trainer=lightning_wandb`, the same way training runs already do.

## Where this came from
Found while setting up a `medrap-eval eval_mode=test retriever.k=1` run in medrap-experiments to evaluate an already-trained `marginalized_output_mode=binary` checkpoint against the held-out split ([MedRAP#94](https://github.com/McDermottHealthAI/MedRAP/pull/94) added `test/auroc/*` logging for exactly this). Verified locally with `hydra.compose` before writing this fix — the override genuinely failed before this change, and succeeds after.

## Test plan
- [x] New test `test_run_eval_accepts_marginalized_and_wandb_overrides` — regression test confirming `marginalized_retrieval=true`, `marginalized_output_mode=binary`, `training/trainer=lightning_wandb`, and `wandb_run_name=...` all compose without error and reach the model/trainer config.
- [x] `pytest tests/test_cli.py -k eval` (8 passed) — confirms existing eval-path tests are unaffected by the additions.
- [x] Full suite: `pytest -q` (196 passed).
- [x] `ruff check`/`ruff format --check` on changed Python files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)