### PR TITLE
fix(eval): support do_overwrite for medrap-eval output_dir

### DIFF
--- a/src/medrap/cli.py
+++ b/src/medrap/cli.py
@@ -284,10 +284,13 @@ def _prepare_eval_run(cfg: DictConfig) -> Path:
     config_path = output_dir / "config.yaml"
 
     if config_path.exists():
-        raise FileExistsError(
-            f"Output directory {output_dir} already contains a saved MedRAP eval run. "
-            "Use a different `output_dir`."
-        )
+        if cfg.do_overwrite:
+            shutil.rmtree(output_dir, ignore_errors=True)
+        else:
+            raise FileExistsError(
+                f"Output directory {output_dir} already contains a saved MedRAP eval run. "
+                "Use `do_overwrite=true` or a different `output_dir`."
+            )
 
     output_dir.mkdir(parents=True, exist_ok=True)
     OmegaConf.save(cfg, config_path)

--- a/src/medrap/conf/_eval.yaml
+++ b/src/medrap/conf/_eval.yaml
@@ -19,6 +19,7 @@ head:
 output_dir: ???
 checkpoint_path: ???
 eval_mode: validate
+do_overwrite: false
 
 hydra:
   run:

--- a/src/medrap/configs.py
+++ b/src/medrap/configs.py
@@ -401,6 +401,7 @@ class RAPEvalConfig(PipelineConfig):
     output_dir: str = MISSING
     checkpoint_path: str = MISSING
     eval_mode: str = "validate"
+    do_overwrite: bool = False
 
 
 @dataclass

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -417,17 +417,21 @@ def test_eval_entrypoint_refuses_existing_output_dir(tmp_path) -> None:
         == 0
     )
 
+    eval_overrides = [
+        f"output_dir={eval_dir}",
+        f"checkpoint_path={checkpoint_path}",
+        "training/datamodule=synthetic",
+    ]
     _assert_cli_failure(
-        lambda: _run_eval_cli(
-            [
-                f"output_dir={eval_dir}",
-                f"checkpoint_path={checkpoint_path}",
-                "training/datamodule=synthetic",
-            ]
-        ),
+        lambda: _run_eval_cli(eval_overrides),
         allowed_exceptions=(SystemExit, FileExistsError),
         expected_message="already contains a saved MedRAP eval run",
     )
+
+    # do_overwrite=true clears the existing run instead of raising -- needed to
+    # re-run an eval against the same output_dir (e.g. after fixing a config
+    # mistake in an earlier attempt) without deleting it by hand first.
+    assert _run_eval_cli([*eval_overrides, "do_overwrite=true"]) == 0
 
 
 def test_ensure_lightning_csv_log_dirs_creates_version_directory(tmp_path) -> None:


### PR DESCRIPTION
## Summary
- `_prepare_eval_run` unconditionally raised `FileExistsError` if `output_dir` already held a saved eval run — unlike `_prepare_retrieve_run`, which already supports `do_overwrite=true` to clear and retry.
- Found this running `medrap-eval eval_mode=test` against the same `output_dir` a second time, after fixing an unrelated config bug (missing `training/loss` override) in the first attempt: every retry failed with `"already contains a saved MedRAP eval run"`, with no way to proceed short of deleting the directory by hand.
- Adds `do_overwrite` (declared on `_eval.yaml` and `RAPEvalConfig`, defaulting to `false` so existing behavior is unchanged unless a caller opts in) and mirrors `_prepare_retrieve_run`'s `shutil.rmtree`-then-recreate handling in `_prepare_eval_run`.

## Test plan
- [x] Extended `test_eval_entrypoint_refuses_existing_output_dir` to also assert `do_overwrite=true` succeeds where the bare rerun still fails.
- [x] `pytest tests/test_cli.py -k eval` (7 passed).
- [x] Full suite: `pytest -q` (195 passed).
- [x] `ruff check`/`ruff format --check` on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)