### PR TITLE
feat(preprocess): sample prediction anchors uniformly over clinical events

### DIFF
--- a/src/medrap/cli.py
+++ b/src/medrap/cli.py
@@ -402,6 +402,7 @@ def preprocess_main(cfg: DictConfig) -> None:
         horizon_days=cfg.horizon_days,
         min_history_days=cfg.min_history_days,
         seed=cfg.seed,
+        anchor_strategy=cfg.anchor_strategy,
     )
     print(f"Task labels saved to {tasks_out}")
 

--- a/src/medrap/conf/_preprocess.yaml
+++ b/src/medrap/conf/_preprocess.yaml
@@ -7,6 +7,7 @@ num_tasks: 25
 horizon_days: 7.0
 min_history_days: 1.0
 seed: 42
+anchor_strategy: uniform_lifetime # or uniform_event: anchor on real clinical events
 do_overwrite: false
 
 hydra:

--- a/src/medrap/configs.py
+++ b/src/medrap/configs.py
@@ -485,4 +485,5 @@ class PreprocessDatasetAppConfig:
     horizon_days: float = 7.0
     min_history_days: float = 1.0
     seed: int = 42
+    anchor_strategy: str = "uniform_lifetime"  # "uniform_lifetime" | "uniform_event"
     do_overwrite: bool = False

--- a/src/medrap/preprocess/README.md
+++ b/src/medrap/preprocess/README.md
@@ -15,14 +15,15 @@ medrap-preprocess \
 
 Key options (all have defaults):
 
-| Option                   | Default | Description                                           |
-| ------------------------ | ------- | ----------------------------------------------------- |
-| `min_subjects_per_code`  | 100     | Drop codes appearing in fewer than this many subjects |
-| `min_events_per_subject` | 10      | Drop subjects with fewer distinct events than this    |
-| `num_tasks`              | 25      | Number of prediction tasks to generate                |
-| `horizon_days`           | 7.0     | How far ahead to look for a code occurrence           |
-| `min_history_days`       | 1.0     | Minimum history required before a prediction time     |
-| `seed`                   | 42      | Random seed for task sampling and prediction times    |
+| Option                   | Default            | Description                                                                                                                     |
+| ------------------------ | ------------------ | ------------------------------------------------------------------------------------------------------------------------------- |
+| `min_subjects_per_code`  | 100                | Drop codes appearing in fewer than this many subjects                                                                           |
+| `min_events_per_subject` | 10                 | Drop subjects with fewer distinct events than this                                                                              |
+| `num_tasks`              | 25                 | Number of prediction tasks to generate                                                                                          |
+| `horizon_days`           | 7.0                | How far ahead to look for a code occurrence                                                                                     |
+| `min_history_days`       | 1.0                | Minimum history required before a prediction time                                                                               |
+| `seed`                   | 42                 | Random seed for task sampling and prediction times                                                                              |
+| `anchor_strategy`        | `uniform_lifetime` | How the prediction time is drawn: `uniform_lifetime` (uniform timestamp) or `uniform_event` (uniform over real clinical events) |
 
 ### Skipping stage 1 (use existing tensorized data)
 
@@ -71,12 +72,18 @@ training time. Output goes to `output_dir/tensorized/`.
 ### Stage 3 — generate_tasks (always runs)
 
 Randomly samples `num_tasks` codes from the train split (excluding
-`TIMELINE//` tokens, which are synthetic) and creates binary prediction labels
+`TIMELINE//` tokens, which are synthetic, and the MEDS birth code, which can
+never fall inside a prediction window) and creates binary prediction labels
 for each subject in every split:
 
-- A single random **prediction time** is drawn per subject, uniformly from
+- A single **prediction time** is drawn per subject from
     `[first_event + min_history_days, last_event - horizon_days]`. Subjects
-    whose timeline is too short for this window are excluded.
+    whose timeline is too short for this window are excluded. `anchor_strategy`
+    selects how: `uniform_lifetime` draws a uniformly random timestamp in that
+    window, while `uniform_event` draws uniformly over the subject's real
+    clinical events inside it. On records spanning decades most uniform-timestamp
+    draws land in stretches with no clinical activity nearby, so labels come out
+    overwhelmingly negative; `uniform_event` puts every anchor on real activity.
 - For each task code, the label is `1.0` if the code appears within
     `horizon_days` after the prediction time, otherwise `0.0`.
 

--- a/src/medrap/preprocess/task_generation.py
+++ b/src/medrap/preprocess/task_generation.py
@@ -1,34 +1,70 @@
 """Multi-task binary label creation from MEDS cohort data.
 
-Prediction time is sampled uniformly at random from the per-subject window
-``[first_event + min_history_days, last_event - horizon_days]``.
-Subjects whose timeline is shorter than ``min_history_days + horizon_days`` are excluded.
+Prediction time is drawn per subject from the window
+``[first_event + min_history_days, last_event - horizon_days]``; subjects whose
+timeline is shorter than ``min_history_days + horizon_days`` are excluded. How the
+point inside that window is drawn is set by ``anchor_strategy`` (see
+:func:`_sample_prediction_anchors`): ``"uniform_lifetime"`` samples a uniformly random
+timestamp, while ``"uniform_event"`` samples uniformly over the subject's real clinical
+events, so every anchor lands on actual clinical activity.
 
 Task codes are sampled uniformly at random from codes present in the train split,
-excluding synthetic time tokens (``TIMELINE//`` prefix) added by the MEDS-transforms
-pipeline (see :func:`_sample_task_codes`). There is no positive-rate or count
-filtering -- a randomly chosen code can turn out rare or degenerate (all-positive or
-all-negative) on a given split; that is a property of the sampled task, not something
-this module tries to correct for.
+excluding synthetic time tokens and birth (see :func:`_clinical_events`). There is no
+positive-rate or count filtering -- a randomly chosen code can turn out rare or
+degenerate (all-positive or all-negative) on a given split; that is a property of the
+sampled task, not something this module tries to correct for.
 """
 
 import json
 import logging
 from pathlib import Path
 
+import meds
 import numpy as np
 import polars as pl
 
 log = logging.getLogger(__name__)
 
 
+def _clinical_events[FrameT: (pl.DataFrame, pl.LazyFrame)](df: FrameT) -> FrameT:
+    """Restrict ``df`` to real clinical events.
+
+    Drops synthetic ``TIMELINE//`` tokens added by the MEDS-transforms pipeline and
+    ``meds.birth_code``. Birth is structurally degenerate as a task: it is the first
+    event on a subject's timeline and prediction anchors are always sampled after it,
+    so it can never fall inside a prediction window. ``TIMELINE//START`` sits at the
+    *same* timestamp as birth, so dropping only one of the two would leave the other
+    as a back door to that instant.
+
+    Task-code selection and anchor sampling share this one filter: a code eligible as
+    a *task* must also be eligible as an *anchor*, or the label semantics diverge.
+
+    Args:
+        df: Frame with a ``code`` column.
+
+    Returns:
+        ``df`` restricted to rows whose ``code`` is neither ``meds.birth_code`` nor a
+        ``TIMELINE//`` token, in the input row order and of the input frame type.
+
+    Examples:
+        >>> _clinical_events(pl.DataFrame({"code": [meds.birth_code, "TIMELINE//START", "DIAG//A"]}))[
+        ...     "code"
+        ... ].to_list()
+        ['DIAG//A']
+    """
+    return df.filter(
+        ~pl.col("code").str.starts_with("TIMELINE//"),
+        pl.col("code") != meds.birth_code,
+    )
+
+
 def _sample_task_codes(meds_data_dir: str | Path, num_tasks: int, seed: int) -> list[str]:
     """Sample ``num_tasks`` codes uniformly at random from the train split.
 
-    Every code present in the train split (excluding synthetic ``TIMELINE//``
-    tokens added by the MEDS-transforms pipeline) is equally eligible; no
-    positive-rate or count filtering is applied. A sampled code may turn out
-    rare or degenerate (all-positive or all-negative) on a given split.
+    Every code present in the train split is equally eligible, except those
+    :func:`_clinical_events` drops (synthetic ``TIMELINE//`` tokens and
+    ``meds.birth_code``); no positive-rate or count filtering is applied. A sampled
+    code may turn out rare or degenerate (all-positive or all-negative) on a split.
 
     Args:
         meds_data_dir: Root of a MEDS dataset (``data/train/*.parquet``).
@@ -58,6 +94,21 @@ def _sample_task_codes(meds_data_dir: str | Path, num_tasks: int, seed: int) -> 
         ...     sorted(_sample_task_codes(tmpdir, num_tasks=2, seed=0))
         ['DIAG//A', 'DIAG//B']
 
+        ``meds.birth_code`` is never eligible, even though every subject has one:
+
+        >>> with tempfile.TemporaryDirectory() as tmpdir:
+        ...     shard_dir = Path(tmpdir) / "data" / "train"
+        ...     shard_dir.mkdir(parents=True)
+        ...     pl.DataFrame(
+        ...         {
+        ...             "subject_id": [1, 1],
+        ...             "code": [meds.birth_code, "DIAG//A"],
+        ...             "time": [datetime(2020, 1, 1), datetime(2020, 1, 2)],
+        ...         }
+        ...     ).write_parquet(shard_dir / "0.parquet")
+        ...     _sample_task_codes(tmpdir, num_tasks=1, seed=0)
+        ['DIAG//A']
+
         Raises when there aren't enough eligible codes:
 
         >>> with tempfile.TemporaryDirectory() as tmpdir:
@@ -74,11 +125,27 @@ def _sample_task_codes(meds_data_dir: str | Path, num_tasks: int, seed: int) -> 
         Traceback (most recent call last):
             ...
         ValueError: No eligible task codes found in .../data/train/.
+
+        ...and when there are some, but fewer than requested:
+
+        >>> with tempfile.TemporaryDirectory() as tmpdir:
+        ...     shard_dir = Path(tmpdir) / "data" / "train"
+        ...     shard_dir.mkdir(parents=True)
+        ...     pl.DataFrame(
+        ...         {
+        ...             "subject_id": [1],
+        ...             "code": ["DIAG//A"],
+        ...             "time": [datetime(2020, 1, 1)],
+        ...         }
+        ...     ).write_parquet(shard_dir / "0.parquet")
+        ...     _sample_task_codes(tmpdir, num_tasks=5, seed=0)  # doctest: +ELLIPSIS
+        Traceback (most recent call last):
+            ...
+        ValueError: Only 1 eligible task codes found in .../data/train/, fewer than the requested num_tasks=5.
     """
     data = pl.scan_parquet(Path(meds_data_dir) / "data" / "train" / "*.parquet")
     eligible = (
-        data.filter(pl.col("time").is_not_null())
-        .filter(~pl.col("code").str.starts_with("TIMELINE//"))
+        _clinical_events(data.filter(pl.col("time").is_not_null()))
         .select("code")
         .unique()
         .collect()["code"]
@@ -97,24 +164,119 @@ def _sample_task_codes(meds_data_dir: str | Path, num_tasks: int, seed: int) -> 
 
 
 def _sample_prediction_anchors(
-    df: pl.DataFrame, horizon_days: float, min_history_days: float, rng: np.random.Generator
+    df: pl.DataFrame,
+    horizon_days: float,
+    min_history_days: float,
+    rng: np.random.Generator,
+    anchor_strategy: str = "uniform_lifetime",
 ) -> pl.DataFrame | None:
     """Sample one random prediction anchor per subject within their valid window.
 
-    Prediction time is sampled uniformly from
-    ``[first_event + min_history_days, last_event - horizon_days]``. Subjects
+    The valid window is ``[first_event + min_history_days, last_event - horizon_days]``
+    either way; ``anchor_strategy`` decides how a point inside it is drawn. Subjects
     whose window is empty are dropped.
 
+    ``"uniform_lifetime"`` samples a uniformly random *timestamp* in that window. On a
+    record spanning decades most draws land in stretches with no clinical activity
+    nearby, so the prediction window is usually empty and labels are overwhelmingly
+    negative. ``"uniform_event"`` instead samples uniformly over the subject's real
+    clinical events (:func:`_clinical_events`) inside the window, so every anchor sits
+    on actual clinical activity.
+
     Args:
-        df: Shard events with ``subject_id`` and ``time`` columns.
+        df: Shard events with ``subject_id``, ``time`` and ``code`` columns.
         horizon_days: Days after prediction time to look for code occurrence.
         min_history_days: Minimum days of history before the prediction anchor.
-        rng: Random generator; consumes one ``rng.random(n_subjects)`` draw.
+        rng: Random generator; consumes one ``rng.random(n_subjects)`` draw either way.
+        anchor_strategy: ``"uniform_lifetime"`` (default) or ``"uniform_event"``.
 
     Returns:
         DataFrame with columns ``subject_id``, ``prediction_time``, or ``None``
         if no subject has a nonempty window.
+
+    Raises:
+        ValueError: If ``anchor_strategy`` is not one of the two known values.
+
+    Examples:
+        Two subjects, each with one clinical event mid-window and a long empty tail.
+        ``"uniform_event"`` must land exactly on that event; ``"uniform_lifetime"``
+        almost surely does not.
+
+        >>> from datetime import datetime
+        >>> events = pl.DataFrame(
+        ...     {
+        ...         "subject_id": [1, 1, 1, 2, 2, 2],
+        ...         "code": ["DIAG//A", "DIAG//B", "DIAG//A", "DIAG//A", "DIAG//B", "DIAG//A"],
+        ...         "time": [
+        ...             datetime(2000, 1, 1),
+        ...             datetime(2010, 6, 1),
+        ...             datetime(2020, 1, 1),
+        ...             datetime(2000, 1, 1),
+        ...             datetime(2010, 6, 1),
+        ...             datetime(2020, 1, 1),
+        ...         ],
+        ...     }
+        ... )
+        >>> rng = np.random.default_rng(0)
+        >>> anchors = _sample_prediction_anchors(events, 7.0, 1.0, rng, anchor_strategy="uniform_event")
+        >>> sorted(anchors["prediction_time"].dt.date().unique().to_list())
+        [datetime.date(2010, 6, 1)]
+
+        Both strategies are reproducible for a fixed seed. This is not automatic:
+        ``group_by`` row order is unspecified, so the draw is zipped positionally
+        against explicitly sorted rows.
+
+        >>> def anchors_for(strategy):
+        ...     return _sample_prediction_anchors(
+        ...         events, 7.0, 1.0, np.random.default_rng(0), anchor_strategy=strategy
+        ...     ).sort("subject_id")
+        >>> all(anchors_for(s).equals(anchors_for(s)) for s in ("uniform_lifetime", "uniform_event"))
+        True
+
+        An unknown strategy is rejected rather than silently falling back:
+
+        >>> _sample_prediction_anchors(events, 7.0, 1.0, rng, anchor_strategy="nearest")
+        Traceback (most recent call last):
+            ...
+        ValueError: anchor_strategy must be 'uniform_lifetime' or 'uniform_event', got 'nearest'
+
+        ``None`` is returned when no anchor can be placed. An empty shard:
+
+        >>> empty = events.clear()
+        >>> _sample_prediction_anchors(empty, 7.0, 1.0, rng) is None
+        True
+
+        A timeline too short to hold ``min_history_days + horizon_days``:
+
+        >>> short = pl.DataFrame(
+        ...     {
+        ...         "subject_id": [1, 1],
+        ...         "code": ["DIAG//A", "DIAG//B"],
+        ...         "time": [datetime(2020, 1, 1), datetime(2020, 1, 2)],
+        ...     }
+        ... )
+        >>> _sample_prediction_anchors(short, 7.0, 1.0, rng) is None
+        True
+
+        And, under ``"uniform_event"`` only, a window that contains no *clinical*
+        event -- here the sole in-window row is a synthetic ``TIMELINE//`` token, so
+        there is nothing to anchor on even though the window itself is valid:
+
+        >>> sparse = pl.DataFrame(
+        ...     {
+        ...         "subject_id": [1, 1, 1],
+        ...         "code": ["DIAG//A", "TIMELINE//DELTA//years", "DIAG//B"],
+        ...         "time": [datetime(2000, 1, 1), datetime(2005, 6, 1), datetime(2010, 1, 1)],
+        ...     }
+        ... )
+        >>> _sample_prediction_anchors(sparse, 7.0, 1.0, rng, anchor_strategy="uniform_event") is None
+        True
     """
+    if anchor_strategy not in ("uniform_lifetime", "uniform_event"):
+        raise ValueError(
+            f"anchor_strategy must be 'uniform_lifetime' or 'uniform_event', got {anchor_strategy!r}"
+        )
+
     if df.is_empty():
         return None
 
@@ -132,17 +294,44 @@ def _sample_prediction_anchors(
             (pl.col("last_us") - horizon_us).alias("latest_us"),
         )
         .filter(pl.col("earliest_us") <= pl.col("latest_us"))
+        # Load-bearing: group_by's row order is unspecified, and the draw below is
+        # zipped positionally against these rows, so without an explicit sort the
+        # same seed pairs different random numbers with different subjects run to run.
+        .sort("subject_id")
     )
 
     if bounds.is_empty():
         return None
 
-    earliest = bounds["earliest_us"].to_numpy()
-    window = (bounds["latest_us"] - bounds["earliest_us"]).to_numpy()
-    offsets = (rng.random(len(bounds)) * window).astype(np.int64)
+    if anchor_strategy == "uniform_event":
+        candidates = (
+            _clinical_events(df)
+            .select("subject_id", pl.col("time").dt.epoch(time_unit="us").alias("event_us"))
+            .join(bounds.select("subject_id", "earliest_us", "latest_us"), on="subject_id")
+            .filter(pl.col("event_us").is_between(pl.col("earliest_us"), pl.col("latest_us")))
+            .sort(["subject_id", "event_us"])
+        )
+        if candidates.is_empty():
+            return None
+
+        # Both .sort()s are load-bearing: group_by's row order is unspecified, so
+        # without them row i of the rng draw would not always mean the same subject.
+        counts = candidates.group_by("subject_id").agg(pl.len().alias("n_events")).sort("subject_id")
+        # .astype(int64) is required: pl.len() is UInt32, and mixing it with the
+        # int64 offsets below would promote the index array to float.
+        n_events = counts["n_events"].to_numpy().astype(np.int64)
+        block_starts = np.cumsum(n_events) - n_events  # exclusive prefix sum
+        picks = block_starts + (rng.random(len(counts)) * n_events).astype(np.int64)
+        subject_ids = counts["subject_id"]
+        prediction_us = candidates["event_us"].to_numpy()[picks]
+    else:
+        earliest = bounds["earliest_us"].to_numpy()
+        window = (bounds["latest_us"] - bounds["earliest_us"]).to_numpy()
+        subject_ids = bounds["subject_id"]
+        prediction_us = earliest + (rng.random(len(bounds)) * window).astype(np.int64)
 
     return (
-        pl.DataFrame({"subject_id": bounds["subject_id"], "prediction_us": earliest + offsets})
+        pl.DataFrame({"subject_id": subject_ids, "prediction_us": prediction_us})
         .with_columns(pl.from_epoch("prediction_us", time_unit="us").alias("prediction_time"))
         .select(["subject_id", "prediction_time"])
     )
@@ -154,17 +343,39 @@ def _generate_labels_shard(
     horizon_days: float,
     min_history_days: float,
     rng: np.random.Generator,
+    anchor_strategy: str = "uniform_lifetime",
 ) -> pl.DataFrame | None:
     """Build multi-task label rows for one shard with a random prediction time per subject.
 
-    Prediction time is sampled uniformly from
-    ``[first_event + min_history_days, last_event - horizon_days]``.
-    Subjects whose window is empty are dropped.
+    Prediction time is drawn from
+    ``[first_event + min_history_days, last_event - horizon_days]`` per
+    ``anchor_strategy`` (see :func:`_sample_prediction_anchors`). Subjects whose
+    window is empty are dropped.
+
+    Examples:
+        Returns ``None`` when no subject in the shard has a usable window, so the
+        caller can skip the shard entirely:
+
+        >>> import tempfile
+        >>> from datetime import datetime
+        >>> with tempfile.TemporaryDirectory() as tmpdir:
+        ...     shard = Path(tmpdir) / "0.parquet"
+        ...     pl.DataFrame(
+        ...         {
+        ...             "subject_id": [1, 1],
+        ...             "code": ["DIAG//A", "DIAG//B"],
+        ...             "time": [datetime(2020, 1, 1), datetime(2020, 1, 2)],
+        ...         }
+        ...     ).write_parquet(shard)
+        ...     _generate_labels_shard(shard, ["DIAG//A"], 7.0, 1.0, np.random.default_rng(0)) is None
+        True
     """
     df = pl.read_parquet(shard_path, columns=["subject_id", "time", "code"]).filter(
         pl.col("time").is_not_null()
     )
-    anchors = _sample_prediction_anchors(df, horizon_days, min_history_days, rng)
+    anchors = _sample_prediction_anchors(
+        df, horizon_days, min_history_days, rng, anchor_strategy=anchor_strategy
+    )
     if anchors is None:
         return None
 
@@ -210,6 +421,7 @@ def generate_labels(
     horizon_days: float,
     min_history_days: float,
     seed: int,
+    anchor_strategy: str = "uniform_lifetime",
 ) -> pl.DataFrame:
     """Generate multi-task binary labels for all shards of one split.
 
@@ -220,6 +432,8 @@ def generate_labels(
         horizon_days: Days after prediction time to look for code occurrence.
         min_history_days: Minimum days of history before the prediction anchor.
         seed: Random seed for reproducible anchor sampling.
+        anchor_strategy: ``"uniform_lifetime"`` (default) or ``"uniform_event"``;
+            see :func:`_sample_prediction_anchors`.
 
     Returns:
         DataFrame with columns ``subject_id``, ``prediction_time``, ``task_0``, …
@@ -255,6 +469,24 @@ def generate_labels(
         Traceback (most recent call last):
             ...
         FileNotFoundError: No shard directory: .../data/train
+
+        An empty frame comes back when the split exists but no shard yields a
+        usable anchor:
+
+        >>> with tempfile.TemporaryDirectory() as tmpdir:
+        ...     shard_dir = Path(tmpdir) / "data" / "train"
+        ...     shard_dir.mkdir(parents=True)
+        ...     pl.DataFrame(
+        ...         {
+        ...             "subject_id": [1, 1],
+        ...             "code": ["A", "B"],
+        ...             "time": [datetime(2020, 1, 1), datetime(2020, 1, 2)],
+        ...         }
+        ...     ).write_parquet(shard_dir / "0.parquet")
+        ...     generate_labels(
+        ...         tmpdir, "train", ["A"], horizon_days=7.0, min_history_days=1.0, seed=0
+        ...     ).is_empty()
+        True
     """
     shard_dir = Path(meds_data_dir) / "data" / split
     if not shard_dir.exists():
@@ -264,7 +496,12 @@ def generate_labels(
     shards = [
         s
         for f in sorted(shard_dir.glob("*.parquet"))
-        if (s := _generate_labels_shard(f, codes, horizon_days, min_history_days, rng)) is not None
+        if (
+            s := _generate_labels_shard(
+                f, codes, horizon_days, min_history_days, rng, anchor_strategy=anchor_strategy
+            )
+        )
+        is not None
     ]
     if not shards:
         return pl.DataFrame()
@@ -280,6 +517,7 @@ def generate_tasks(
     min_history_days: float = 1.0,
     seed: int = 42,
     splits: tuple[str, ...] = ("train", "tuning", "held_out"),
+    anchor_strategy: str = "uniform_lifetime",
 ) -> Path:
     """Create multi-task binary labels from a MEDS cohort.
 
@@ -297,6 +535,10 @@ def generate_tasks(
         min_history_days: Minimum days of history before the prediction anchor.
         seed: Random seed for task selection and anchor sampling.
         splits: Splits to generate labels for.
+        anchor_strategy: ``"uniform_lifetime"`` (default) samples a uniformly random
+            timestamp in each subject's valid window; ``"uniform_event"`` samples
+            uniformly over their real clinical events inside it, so every anchor lands
+            on actual clinical activity. See :func:`_sample_prediction_anchors`.
 
     Returns:
         ``output_dir`` as a ``Path``.
@@ -321,6 +563,26 @@ def generate_tasks(
         ...     is_ok = returned == out_dir and (out_dir / "train.parquet").exists()
         ...     is_ok and codes == {"0": "DIAG//A"}
         True
+
+        A split whose subjects all have unusable windows is skipped rather than
+        written as an empty parquet -- here ``tuning`` has one 2-day timeline, too
+        short to hold ``min_history_days + horizon_days``:
+
+        >>> with tempfile.TemporaryDirectory() as tmpdir:
+        ...     for split, days in (("train", 20), ("tuning", 1)):
+        ...         shard_dir = Path(tmpdir) / "data" / split
+        ...         shard_dir.mkdir(parents=True)
+        ...         rows = {"subject_id": [], "code": [], "time": []}
+        ...         for subject_id in range(5):
+        ...             start = datetime(2020, 1, 1) + timedelta(days=subject_id)
+        ...             rows["subject_id"] += [subject_id, subject_id]
+        ...             rows["code"] += ["DIAG//A", "DIAG//B"]
+        ...             rows["time"] += [start, start + timedelta(days=days)]
+        ...         pl.DataFrame(rows).write_parquet(shard_dir / "0.parquet")
+        ...     out_dir = Path(tmpdir) / "tasks"
+        ...     _ = generate_tasks(tmpdir, out_dir, num_tasks=1, seed=0, splits=("train", "tuning"))
+        ...     (out_dir / "train.parquet").exists(), (out_dir / "tuning.parquet").exists()
+        (True, False)
     """
     meds_data_dir = Path(meds_data_dir)
     output_dir = Path(output_dir)
@@ -329,7 +591,15 @@ def generate_tasks(
     codes = _sample_task_codes(meds_data_dir, num_tasks=num_tasks, seed=seed)
 
     for split in splits:
-        df = generate_labels(meds_data_dir, split, codes, horizon_days, min_history_days, seed)
+        df = generate_labels(
+            meds_data_dir,
+            split,
+            codes,
+            horizon_days,
+            min_history_days,
+            seed,
+            anchor_strategy=anchor_strategy,
+        )
         if df.is_empty():
             continue
         df.write_parquet(output_dir / f"{split}.parquet")
@@ -344,6 +614,7 @@ def generate_tasks(
                 "horizon_days": horizon_days,
                 "min_history_days": min_history_days,
                 "seed": seed,
+                "anchor_strategy": anchor_strategy,
                 "codes": codes,
             },
             indent=2,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -710,9 +710,11 @@ def test_preprocess_entrypoint_runs_with_hydra_overrides(monkeypatch, tmp_path) 
         horizon_days,
         min_history_days,
         seed,
+        anchor_strategy,
     ):
         captured["meds_data_dir"] = str(meds_data_dir)
         captured["num_tasks"] = num_tasks
+        captured["anchor_strategy"] = anchor_strategy
         Path(output_dir).mkdir(parents=True, exist_ok=True)
         return Path(output_dir)
 
@@ -729,12 +731,14 @@ def test_preprocess_entrypoint_runs_with_hydra_overrides(monkeypatch, tmp_path) 
                 f"output_dir={output_dir}",
                 f"tensorized_dir={tensorized_dir}",
                 "num_tasks=5",
+                "anchor_strategy=uniform_event",
             ]
         )
         == 0
     )
     assert captured["meds_data_dir"] == str(meds_data_dir)
     assert captured["num_tasks"] == 5
+    assert captured["anchor_strategy"] == "uniform_event"
     assert (output_dir / "config.yaml").exists()
     assert (output_dir / "resolved_config.yaml").exists()
 
@@ -758,6 +762,7 @@ def test_preprocess_entrypoint_runs_without_tensorized_dir(monkeypatch, tmp_path
         horizon_days,
         min_history_days,
         seed,
+        anchor_strategy,
     ):
         Path(output_dir).mkdir(parents=True, exist_ok=True)
         return Path(output_dir)


### PR DESCRIPTION
## Summary

Adds `anchor_strategy=uniform_event`, which samples each subject's prediction anchor
uniformly over their **real clinical events** rather than uniformly over wall-clock time.

Today's anchor is a random timestamp in
`[first_event + min_history_days, last_event - horizon_days]`. On MIMIC-IV, where records
span decades, most draws land in stretches with no clinical activity nearby — so the
prediction window is usually empty and labels come out almost entirely negative. Measured
on the real cohort the median task had a **0.22% positive rate**, with tasks routinely
ending up with single-digit positives in the scored split, where AUROC is decided by which
few patients happened to land there.

`uniform_event` puts every anchor on a timestamp where something actually happened.

## Impact

Measured end-to-end on `MEDS_cohort/intermediate`, 7-day horizon:

| metric | `uniform_lifetime` | `uniform_event` |
| --- | --- | --- |
| median positive rate | 0.0022 | **0.2057** (91.9×) |
| anchors on a real clinical event | — | 554 / 554 |
| anchors at birth | — | 0 |

~17% of otherwise-eligible subjects drop out: they have no clinical event inside their
window, so there is nothing to anchor on.

`uniform_lifetime` remains the default — existing pipelines are unaffected unless they opt in.

## Scope

**~56 lines** implement the feature. **~13 lines** are two small prerequisite fixes:
`meds.birth_code` was eligible as both a task code and an anchor (birth can never fall
inside a prediction window), and anchor sampling wasn't reproducible because `group_by`
row order is unspecified while the RNG draw was zipped against it positionally — a fixed
seed matched only 1 of 40 anchors across runs. Note the sort fix does change
`uniform_lifetime` anchors for a given seed; there was no stable behaviour to preserve.

The remaining **~228 lines** are docstrings and doctests, taking `task_generation.py`
from 91% to 100% coverage.

## Testing

202 passing, `pre-commit` clean. Verified the default path is byte-identical to `main`
under conditions where `main` is itself deterministic.
